### PR TITLE
Fix webhook email ID mismatch for v2 replies

### DIFF
--- a/@inboundemail/sdk/src/webhook-types.ts
+++ b/@inboundemail/sdk/src/webhook-types.ts
@@ -94,7 +94,7 @@ export interface InboundParsedEmailData {
 
 // Email data structure in webhook
 export interface InboundWebhookEmail {
-  id: string
+  id: string // Structured email ID (compatible with v2 API reply endpoint)
   messageId: string | null
   from: InboundEmailAddress | null
   to: InboundEmailAddress | null

--- a/app/api/inbound/webhook/route.ts
+++ b/app/api/inbound/webhook/route.ts
@@ -490,7 +490,7 @@ export async function triggerEmailAction(emailId: string): Promise<{ success: bo
       event: 'email.received',
       timestamp: new Date().toISOString(),
       email: {
-        id: emailData.emailId,
+        id: emailData.structuredId, // Use structured email ID for v2 API compatibility
         messageId: emailData.messageId,
         from: emailData.from,
         to: JSON.parse(emailData.to),
@@ -534,7 +534,7 @@ export async function triggerEmailAction(emailId: string): Promise<{ success: bo
       'X-Webhook-Event': 'email.received',
       'X-Webhook-ID': webhook.id,
       'X-Webhook-Timestamp': webhookPayload.timestamp,
-      'X-Email-ID': emailData.emailId,
+      'X-Email-ID': emailData.structuredId, // Use structured email ID for v2 API compatibility
       'X-Message-ID': emailData.messageId,
     }
 

--- a/lib/email-management/email-router.ts
+++ b/lib/email-management/email-router.ts
@@ -295,7 +295,7 @@ async function handleWebhookEndpoint(emailId: string, endpoint: Endpoint): Promi
       event: 'email.received',
       timestamp: new Date().toISOString(),
       email: {
-        id: emailData.emailId,
+        id: emailData.structuredId, // Use structured email ID for v2 API compatibility
         messageId: emailData.messageId,
         from: emailData.fromData ? JSON.parse(emailData.fromData) : null,
         to: emailData.toData ? JSON.parse(emailData.toData) : null,
@@ -332,7 +332,7 @@ async function handleWebhookEndpoint(emailId: string, endpoint: Endpoint): Promi
       'X-Webhook-Event': 'email.received',
       'X-Endpoint-ID': endpoint.id,
       'X-Webhook-Timestamp': webhookPayload.timestamp,
-      'X-Email-ID': emailData.emailId,
+      'X-Email-ID': emailData.structuredId, // Use structured email ID for v2 API compatibility
       'X-Message-ID': emailData.messageId || '',
       ...customHeaders
     }


### PR DESCRIPTION
Update webhook payloads and headers to send the structured email ID for v2 API compatibility.

Previously, webhooks sent the `receivedEmails.id` (original email ID), while the v2 API reply endpoint and the dashboard expected the `structuredEmails.id`. This mismatch prevented users from using the email ID received via webhooks to reply to emails through the v2 API. This PR aligns the webhook ID with the expected `structuredEmails.id`.

---

[Open in Web](https://www.cursor.com/agents?id=bc-84ab00d2-1ac1-42ff-b963-f5b347215d1e) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-84ab00d2-1ac1-42ff-b963-f5b347215d1e)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated webhook payloads and headers to use a structured email ID for improved compatibility with the v2 API.

* **Documentation**
  * Clarified the meaning of the email ID in code comments to indicate its compatibility with the v2 API reply endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->