### PR TITLE
Fix duplicate message id header error

### DIFF
--- a/app/api/v2/emails/[id]/reply/route.ts
+++ b/app/api/v2/emails/[id]/reply/route.ts
@@ -118,6 +118,10 @@ function buildRawEmailMessage(params: {
 }): string {
     const boundary = `----=_Part_${nanoid()}`
     
+    // Check if Message-ID is provided in custom headers
+    const hasCustomMessageId = params.customHeaders && 
+        Object.keys(params.customHeaders).some(key => key.toLowerCase() === 'message-id')
+    
     // Build headers
     let headers = [
         `From: ${params.from}`,
@@ -125,7 +129,8 @@ function buildRawEmailMessage(params: {
         params.cc && params.cc.length > 0 ? `Cc: ${params.cc.join(', ')}` : null,
         params.replyTo && params.replyTo.length > 0 ? `Reply-To: ${params.replyTo.join(', ')}` : null,
         `Subject: ${params.subject}`,
-        `Message-ID: <${params.messageId}@${extractDomain(params.from)}>`,
+        // Only add Message-ID if not provided in custom headers
+        !hasCustomMessageId ? `Message-ID: <${params.messageId}@${extractDomain(params.from)}>` : null,
         params.inReplyTo ? `In-Reply-To: ${params.inReplyTo}` : null,
         params.references && params.references.length > 0 ? `References: ${params.references.join(' ')}` : null,
         `Date: ${formatEmailDate(params.date)}`,
@@ -444,7 +449,13 @@ export async function POST(
 
         // Create sent email record
         const replyEmailId = nanoid()
-        const messageId = `${replyEmailId}@${fromDomain}`
+        
+        // Check if a custom Message-ID is provided
+        let messageId = `${replyEmailId}@${fromDomain}`
+        if (body.headers && body.headers['Message-ID']) {
+            // Extract the Message-ID value (remove angle brackets if present)
+            messageId = body.headers['Message-ID'].replace(/^<|>$/g, '')
+        }
         
         console.log('💾 Creating sent email record:', replyEmailId)
         


### PR DESCRIPTION
Prevent duplicate Message-ID headers in outgoing emails by checking for user-provided IDs and using them if present.

Previously, the system would always generate a Message-ID, leading to a "Duplicate header 'Message-ID'" error from AWS SES if the user also included one in custom headers. This change resolves the 400 error by ensuring only one Message-ID is present.

---

[Open in Web](https://cursor.com/agents?id=bc-9394e6fe-fac2-40ff-babd-261a18953d1e) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-9394e6fe-fac2-40ff-babd-261a18953d1e) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)