### PR TITLE
Fix inbound email headers type mismatch

### DIFF
--- a/@inboundemail/sdk/examples/handle-received-headers.ts
+++ b/@inboundemail/sdk/examples/handle-received-headers.ts
@@ -1,0 +1,145 @@
+/**
+ * Example: Handling Received Headers in Webhook Payloads
+ * 
+ * This example demonstrates how to properly handle the 'received' header field
+ * which can be either a string (single header) or string[] (multiple headers).
+ */
+
+import { InboundWebhookPayload, InboundEmailHeaders } from '../src/webhook-types';
+
+/**
+ * Safely extract received headers as an array
+ */
+function getReceivedHeaders(headers: InboundEmailHeaders): string[] {
+  if (!headers.received) {
+    return [];
+  }
+  
+  // Handle both single string and array cases
+  return Array.isArray(headers.received) ? headers.received : [headers.received];
+}
+
+/**
+ * Parse received headers to extract mail server information
+ */
+function parseReceivedHeaders(headers: InboundEmailHeaders) {
+  const receivedHeaders = getReceivedHeaders(headers);
+  
+  return receivedHeaders.map((header, index) => {
+    // Simple regex to extract from/by information
+    const fromMatch = header.match(/from\s+([^\s]+)/i);
+    const byMatch = header.match(/by\s+([^\s]+)/i);
+    const ipMatch = header.match(/\[([0-9.]+)\]/);
+    
+    return {
+      hop: index + 1,
+      from: fromMatch ? fromMatch[1] : null,
+      by: byMatch ? byMatch[1] : null,
+      ip: ipMatch ? ipMatch[1] : null,
+      raw: header
+    };
+  });
+}
+
+/**
+ * Example webhook handler
+ */
+export function handleEmailWebhook(payload: InboundWebhookPayload) {
+  const { email } = payload;
+  
+  console.log(`Processing email: ${email.subject}`);
+  console.log(`From: ${email.from?.text || 'Unknown'}`);
+  
+  // Handle received headers from parsed data
+  const parsedHeaders = email.parsedData.headers;
+  const receivedHops = parseReceivedHeaders(parsedHeaders);
+  
+  console.log(`\nEmail routing path (${receivedHops.length} hops):`);
+  receivedHops.forEach(hop => {
+    console.log(`  ${hop.hop}. ${hop.from} -> ${hop.by} ${hop.ip ? `(${hop.ip})` : ''}`);
+  });
+  
+  // Also handle received headers from cleaned content
+  const cleanedHeaders = email.cleanedContent.headers;
+  const cleanedReceivedHops = parseReceivedHeaders(cleanedHeaders);
+  
+  if (cleanedReceivedHops.length > 0) {
+    console.log(`\nCleaned content also has ${cleanedReceivedHops.length} received headers`);
+  }
+  
+  // Example: Check if email came through a specific mail server
+  const cameFromAmazonSES = receivedHops.some(hop => 
+    hop.from?.includes('amazonses.com') || hop.by?.includes('amazonses.com')
+  );
+  
+  if (cameFromAmazonSES) {
+    console.log('✅ Email was processed through Amazon SES');
+  }
+  
+  return {
+    processed: true,
+    hops: receivedHops.length,
+    fromSES: cameFromAmazonSES
+  };
+}
+
+// Example usage with mock data
+if (require.main === module) {
+  const mockPayload: InboundWebhookPayload = {
+    event: 'email.received',
+    timestamp: new Date().toISOString(),
+    email: {
+      id: 'test-email-123',
+      messageId: '<test@example.com>',
+      from: { text: 'sender@example.com', addresses: [{ name: 'Sender', address: 'sender@example.com' }] },
+      to: { text: 'recipient@domain.com', addresses: [{ name: null, address: 'recipient@domain.com' }] },
+      recipient: 'recipient@domain.com',
+      subject: 'Test Email',
+      receivedAt: new Date().toISOString(),
+      parsedData: {
+        messageId: '<test@example.com>',
+        date: new Date(),
+        subject: 'Test Email',
+        from: { text: 'sender@example.com', addresses: [{ name: 'Sender', address: 'sender@example.com' }] },
+        to: { text: 'recipient@domain.com', addresses: [{ name: null, address: 'recipient@domain.com' }] },
+        cc: null,
+        bcc: null,
+        replyTo: null,
+        inReplyTo: undefined,
+        references: undefined,
+        textBody: 'This is a test email.',
+        htmlBody: undefined,
+        attachments: [],
+        headers: {
+          // Example with multiple received headers (array)
+          'received': [
+            'from mail1.example.com (mail1.example.com [192.168.1.1]) by mail2.example.com with SMTP id abc123 for <recipient@domain.com>; Mon, 01 Jan 2024 12:00:00 +0000',
+            'from mail0.example.com (mail0.example.com [192.168.1.0]) by mail1.example.com with SMTP id def456 for <recipient@domain.com>; Mon, 01 Jan 2024 11:59:00 +0000'
+          ],
+          'from': { text: 'sender@example.com', addresses: [{ name: 'Sender', address: 'sender@example.com' }] },
+          'to': { text: 'recipient@domain.com', addresses: [{ name: null, address: 'recipient@domain.com' }] },
+          'subject': 'Test Email'
+        },
+        priority: undefined
+      },
+      cleanedContent: {
+        html: null,
+        text: 'This is a test email.',
+        hasHtml: false,
+        hasText: true,
+        attachments: [],
+        headers: {
+          // Example with single received header (string)
+          'received': 'from mail1.example.com (mail1.example.com [192.168.1.1]) by inbound-smtp.amazonaws.com with SMTP id xyz789 for <recipient@domain.com>; Mon, 01 Jan 2024 12:01:00 +0000'
+        }
+      }
+    },
+    endpoint: {
+      id: 'webhook-123',
+      name: 'Test Webhook',
+      type: 'webhook'
+    }
+  };
+  
+  handleEmailWebhook(mockPayload);
+}

--- a/@inboundemail/sdk/src/webhook-types.ts
+++ b/@inboundemail/sdk/src/webhook-types.ts
@@ -29,7 +29,7 @@ export interface InboundEmailHeaders extends Record<string, any> {
     text?: string
     params?: Record<string, string>
   }
-  'received'?: string
+  'received'?: string | string[]
   'received-spf'?: string
   'authentication-results'?: string
   'x-ses-receipt'?: string

--- a/lib/email-management/email-parser.ts
+++ b/lib/email-management/email-parser.ts
@@ -58,7 +58,7 @@ interface ParsedEmailData {
   }>
   headers: Record<string, any> & {
     'return-path'?: ParsedEmailHeaderValue
-    'received'?: string
+    'received'?: string | string[]
     'received-spf'?: string
     'authentication-results'?: string
     'x-ses-receipt'?: string


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Update `received` email header type to `string | string[]` to align with actual webhook payloads.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
Email `Received` headers can appear multiple times (one per mail server hop). The `mailparser` library correctly parses these into an array of strings, but the SDK and internal types only expected a single string. This update ensures type correctness and robust handling of email routing information.

---

[Open in Web](https://cursor.com/agents?id=bc-3ee796b4-98d3-49a0-834d-9276acefd186) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-3ee796b4-98d3-49a0-834d-9276acefd186) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)