### PR TITLE
Add space between email subject prefix

### DIFF
--- a/inbound-app/lib/email-management/email-forwarder.ts
+++ b/inbound-app/lib/email-management/email-forwarder.ts
@@ -26,7 +26,7 @@ export class EmailForwarder {
 
     // Build email subject with optional prefix
     const subject = options?.subjectPrefix 
-      ? `${options.subjectPrefix}${originalEmail.subject || 'No Subject'}`
+      ? `${options.subjectPrefix}${options.subjectPrefix.endsWith(' ') ? '' : ' '}${originalEmail.subject || 'No Subject'}`
       : originalEmail.subject || 'No Subject'
 
     // Construct the "via Inbound" from address format


### PR DESCRIPTION
Add a space between the email subject prefix and the subject to improve readability and prevent cramped subject lines.

Previously, the prefix was directly concatenated, leading to `[Prefix]Subject`. This change ensures a space is always present, resulting in `[Prefix] Subject`, while also preventing double spaces if the user's prefix already includes a trailing space.

---
<a href="https://cursor.com/background-agent?bcId=bc-054aca8d-f452-4c9f-aeda-9d6efbb8fcb0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-054aca8d-f452-4c9f-aeda-9d6efbb8fcb0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

