### PR TITLE
Embed images inline in emails

### DIFF
--- a/@inboundemail/sdk/CHANGELOG.md
+++ b/@inboundemail/sdk/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to the @inboundemail/sdk will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### ✨ Added
+- **Inline Images Support**: Full support for embedding inline images in emails
+  - Added `contentId` field to attachment types for inline image references
+  - Support for both remote URLs and base64-encoded local images
+  - Compatible with Resend's inline images API
+  - Comprehensive utility functions for inline image management:
+    - `createRemoteInlineImage()` - Create remote inline image attachments
+    - `createBase64InlineImage()` - Create base64 inline image attachments
+    - `generateContentId()` - Generate unique content IDs
+    - `validateContentId()` - Validate content ID format
+    - `extractContentIdsFromHtml()` - Extract content IDs from HTML
+    - `validateInlineImageReferences()` - Validate HTML references match attachments
+    - `getContentTypeFromExtension()` - Auto-detect content types
+  - Added comprehensive examples and test cases
+  - Updated documentation with inline images section
+
 ## [3.0.0] - 2025-01-23
 
 ### 🚨 BREAKING CHANGES

--- a/@inboundemail/sdk/README.md
+++ b/@inboundemail/sdk/README.md
@@ -253,6 +253,171 @@ await inbound.send({
 })
 ```
 
+### Inline Images
+
+Send emails with inline images embedded directly in the HTML body. Inline images are sent as attachments with `contentId` references.
+
+#### Remote Inline Images
+
+```typescript
+await inbound.emails.send({
+  from: 'Acme <hello@yourdomain.com>',
+  to: 'user@example.com',
+  subject: 'Welcome to Acme',
+  html: '<p>Here is our <img src="cid:logo-image"/> inline logo</p>',
+  attachments: [
+    {
+      path: 'https://resend.com/static/sample/logo.png',
+      filename: 'logo.png',
+      contentId: 'logo-image'
+    }
+  ]
+})
+```
+
+#### Local Inline Images (Base64)
+
+```typescript
+import * as fs from 'fs'
+
+const imageBuffer = fs.readFileSync('./logo.png')
+const imageBase64 = imageBuffer.toString('base64')
+
+await inbound.emails.send({
+  from: 'Acme <hello@yourdomain.com>',
+  to: 'user@example.com',
+  subject: 'Welcome to Acme',
+  html: '<p>Here is our <img src="cid:logo-image"/> inline logo</p>',
+  attachments: [
+    {
+      content: imageBase64,
+      filename: 'logo.png',
+      contentType: 'image/png',
+      contentId: 'logo-image'
+    }
+  ]
+})
+```
+
+#### Multiple Inline Images
+
+```typescript
+await inbound.emails.send({
+  from: 'Newsletter <news@yourdomain.com>',
+  to: 'subscriber@example.com',
+  subject: 'Monthly Newsletter',
+  html: `
+    <div>
+      <img src="cid:header" alt="Header" style="width: 300px;"/>
+      <h1>Monthly Update</h1>
+      <p>Check out our featured product:</p>
+      <img src="cid:product" alt="Product" style="width: 200px;"/>
+    </div>
+  `,
+  attachments: [
+    {
+      path: 'https://via.placeholder.com/300x100/0066cc/ffffff?text=Newsletter',
+      filename: 'header.png',
+      contentId: 'header'
+    },
+    {
+      path: 'https://via.placeholder.com/200x200/28a745/ffffff?text=Product',
+      filename: 'product.png',
+      contentId: 'product'
+    }
+  ]
+})
+```
+
+#### Mixed Attachments (Regular + Inline)
+
+```typescript
+await inbound.emails.send({
+  from: 'Billing <billing@yourdomain.com>',
+  to: 'customer@example.com',
+  subject: 'Invoice Attached',
+  html: `
+    <div>
+      <h1>Invoice</h1>
+      <p>Please find your invoice attached.</p>
+      <img src="cid:company-logo" alt="Logo" style="width: 100px;"/>
+    </div>
+  `,
+  attachments: [
+    {
+      // Regular attachment (no contentId)
+      path: 'https://example.com/invoice.pdf',
+      filename: 'invoice-2024.pdf',
+      contentType: 'application/pdf'
+    },
+    {
+      // Inline image (with contentId)
+      path: 'https://resend.com/static/sample/logo.png',
+      filename: 'logo.png',
+      contentType: 'image/png',
+      contentId: 'company-logo'
+    }
+  ]
+})
+```
+
+#### Using Utility Functions
+
+The SDK provides utility functions to make working with inline images easier:
+
+```typescript
+import { 
+  createRemoteInlineImage,
+  createBase64InlineImage,
+  generateContentId,
+  validateContentId,
+  extractContentIdsFromHtml,
+  validateInlineImageReferences
+} from '@inboundemail/sdk'
+
+// Create remote inline image attachment
+const logoAttachment = createRemoteInlineImage(
+  'https://resend.com/static/sample/logo.png',
+  'company-logo',
+  'logo.png'
+)
+
+// Generate unique contentId
+const uniqueId = generateContentId('banner') // e.g., "banner-1704067200000-a1b2c3"
+
+// Validate contentId
+const isValid = validateContentId('my-image-123') // true
+const isInvalid = validateContentId('invalid@id') // false
+
+// Extract contentIds from HTML
+const html = '<img src="cid:logo"/> and <img src="cid:banner"/>'
+const contentIds = extractContentIdsFromHtml(html) // ['logo', 'banner']
+
+// Validate that all references have corresponding attachments
+const validation = validateInlineImageReferences(html, attachments)
+if (!validation.isValid) {
+  console.log('Missing attachments:', validation.missingContentIds)
+  console.log('Unused attachments:', validation.unusedContentIds)
+}
+
+// Send email with utility-created attachments
+await inbound.emails.send({
+  from: 'hello@yourdomain.com',
+  to: 'user@example.com',
+  subject: 'Welcome',
+  html: '<p>Logo: <img src="cid:company-logo"/></p>',
+  attachments: [logoAttachment]
+})
+```
+
+#### Important Notes
+
+- **ContentId Requirements**: Must be less than 128 characters and contain only alphanumeric characters, hyphens, underscores, and periods
+- **HTML Reference**: Use `cid:your-content-id` in the `src` attribute of `<img>` tags
+- **Content Type**: Always specify `contentType` for better email client compatibility
+- **Base64 Encoding**: Required when sending local file content via the `content` field
+- **Mixed Attachments**: Attachments without `contentId` appear as regular attachments, while those with `contentId` are embedded inline
+
 ### Retrieving Sent Emails
 
 ```typescript

--- a/@inboundemail/sdk/examples/inline-images-basic.js
+++ b/@inboundemail/sdk/examples/inline-images-basic.js
@@ -1,0 +1,149 @@
+/**
+ * Basic Inline Images Example - Inbound Email SDK (JavaScript)
+ * 
+ * This example shows the simplest way to send emails with inline images
+ * using the Inbound Email SDK in plain JavaScript.
+ */
+
+const { Inbound } = require('../dist/index.js')
+
+// Initialize the client
+const inbound = new Inbound('your-api-key-here')
+
+// Example 1: Remote inline image (simplest approach)
+async function sendWithRemoteImage() {
+  try {
+    const result = await inbound.emails.send({
+      from: 'Acme <hello@yourdomain.com>',
+      to: 'recipient@example.com',
+      subject: 'Welcome to Acme!',
+      html: '<p>Welcome! Here is our logo: <img src="cid:logo"/></p>',
+      attachments: [
+        {
+          path: 'https://resend.com/static/sample/logo.png',
+          filename: 'logo.png',
+          contentId: 'logo'
+        }
+      ]
+    })
+
+    console.log('✅ Email sent:', result.id)
+    return result
+  } catch (error) {
+    console.error('❌ Error:', error.message)
+  }
+}
+
+// Example 2: Local inline image with base64
+async function sendWithLocalImage() {
+  const fs = require('fs')
+  
+  try {
+    // Read and encode image
+    const imageBuffer = fs.readFileSync('./logo.png')
+    const imageBase64 = imageBuffer.toString('base64')
+
+    const result = await inbound.emails.send({
+      from: 'Acme <hello@yourdomain.com>',
+      to: 'recipient@example.com',
+      subject: 'Welcome to Acme!',
+      html: '<p>Welcome! Here is our logo: <img src="cid:logo"/></p>',
+      attachments: [
+        {
+          content: imageBase64,
+          filename: 'logo.png',
+          contentType: 'image/png',
+          contentId: 'logo'
+        }
+      ]
+    })
+
+    console.log('✅ Email sent:', result.id)
+    return result
+  } catch (error) {
+    console.error('❌ Error:', error.message)
+  }
+}
+
+// Example 3: Multiple inline images
+async function sendWithMultipleImages() {
+  try {
+    const result = await inbound.emails.send({
+      from: 'Newsletter <news@yourdomain.com>',
+      to: 'subscriber@example.com',
+      subject: 'Monthly Update',
+      html: `
+        <h1><img src="cid:header" alt="Header"/></h1>
+        <p>Check out our latest product:</p>
+        <img src="cid:product" alt="Product" style="width: 200px;"/>
+        <p>Thanks for reading!</p>
+      `,
+      attachments: [
+        {
+          path: 'https://via.placeholder.com/400x100/0066cc/ffffff?text=Newsletter',
+          filename: 'header.png',
+          contentId: 'header'
+        },
+        {
+          path: 'https://via.placeholder.com/200x200/28a745/ffffff?text=Product',
+          filename: 'product.png',
+          contentId: 'product'
+        }
+      ]
+    })
+
+    console.log('✅ Newsletter sent:', result.id)
+    return result
+  } catch (error) {
+    console.error('❌ Error:', error.message)
+  }
+}
+
+// Example 4: Reply with inline image
+async function replyWithImage(emailId) {
+  try {
+    const result = await inbound.emails.reply(emailId, {
+      from: 'Support <support@yourdomain.com>',
+      html: `
+        <p>Thanks for contacting us!</p>
+        <img src="cid:signature" alt="Signature"/>
+      `,
+      attachments: [
+        {
+          path: 'https://via.placeholder.com/200x50/333333/ffffff?text=Support+Team',
+          filename: 'signature.png',
+          contentId: 'signature'
+        }
+      ]
+    })
+
+    console.log('✅ Reply sent:', result.id)
+    return result
+  } catch (error) {
+    console.error('❌ Error:', error.message)
+  }
+}
+
+// Run examples
+async function main() {
+  console.log('🚀 Testing inline images...\n')
+
+  await sendWithRemoteImage()
+  // await sendWithLocalImage() // Uncomment if you have logo.png
+  await sendWithMultipleImages()
+  
+  console.log('\n✅ Done!')
+}
+
+// Export functions
+module.exports = {
+  sendWithRemoteImage,
+  sendWithLocalImage,
+  sendWithMultipleImages,
+  replyWithImage
+}
+
+// Run if called directly
+if (require.main === module) {
+  main()
+}

--- a/@inboundemail/sdk/examples/inline-images-with-utils.ts
+++ b/@inboundemail/sdk/examples/inline-images-with-utils.ts
@@ -1,0 +1,284 @@
+/**
+ * Inline Images with Utilities Example - Inbound Email SDK
+ * 
+ * This example demonstrates how to use the built-in utility functions
+ * to work with inline images more easily and safely.
+ */
+
+import { 
+  Inbound,
+  createRemoteInlineImage,
+  createBase64InlineImage,
+  generateContentId,
+  validateContentId,
+  extractContentIdsFromHtml,
+  validateInlineImageReferences,
+  getContentTypeFromExtension
+} from '../src/index'
+
+// Initialize the client
+const inbound = new Inbound('your-api-key-here')
+
+/**
+ * Example 1: Using utility functions to create remote inline images
+ */
+async function sendEmailWithUtilityRemoteImage() {
+  try {
+    // Use utility to create inline image attachment
+    const logoAttachment = createRemoteInlineImage(
+      'https://resend.com/static/sample/logo.png',
+      'company-logo',
+      'logo.png'
+    )
+
+    const result = await inbound.emails.send({
+      from: 'Acme <hello@yourdomain.com>',
+      to: ['recipient@example.com'],
+      subject: 'Welcome with utility-created inline image',
+      html: '<p>Welcome! Here is our logo: <img src="cid:company-logo" alt="Logo"/></p>',
+      attachments: [logoAttachment]
+    })
+
+    console.log('✅ Email sent with utility-created remote image:', result.id)
+    return result
+  } catch (error) {
+    console.error('❌ Error:', error)
+    throw error
+  }
+}
+
+/**
+ * Example 2: Using utility functions to create base64 inline images
+ */
+async function sendEmailWithUtilityBase64Image() {
+  try {
+    // Simple 1x1 transparent PNG in base64
+    const base64Image = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChAI9jU77zgAAAABJRU5ErkJggg=="
+
+    // Use utility to create inline image attachment
+    const imageAttachment = createBase64InlineImage(
+      base64Image,
+      'pixel.png',
+      'transparent-pixel',
+      'image/png'
+    )
+
+    const result = await inbound.emails.send({
+      from: 'Acme <hello@yourdomain.com>',
+      to: ['recipient@example.com'],
+      subject: 'Email with utility-created base64 image',
+      html: '<p>Here is a transparent pixel: <img src="cid:transparent-pixel" alt="Pixel"/></p>',
+      attachments: [imageAttachment]
+    })
+
+    console.log('✅ Email sent with utility-created base64 image:', result.id)
+    return result
+  } catch (error) {
+    console.error('❌ Error:', error)
+    throw error
+  }
+}
+
+/**
+ * Example 3: Auto-generating contentIds
+ */
+async function sendEmailWithGeneratedContentIds() {
+  try {
+    // Generate unique contentIds
+    const logoId = generateContentId('logo')
+    const bannerId = generateContentId('banner')
+
+    console.log('Generated contentIds:', { logoId, bannerId })
+
+    const result = await inbound.emails.send({
+      from: 'Newsletter <newsletter@yourdomain.com>',
+      to: ['subscriber@example.com'],
+      subject: 'Newsletter with auto-generated contentIds',
+      html: `
+        <div>
+          <img src="cid:${logoId}" alt="Logo" style="width: 100px;"/>
+          <h1>Monthly Newsletter</h1>
+          <img src="cid:${bannerId}" alt="Banner" style="width: 300px;"/>
+          <p>Thanks for subscribing!</p>
+        </div>
+      `,
+      attachments: [
+        createRemoteInlineImage(
+          'https://resend.com/static/sample/logo.png',
+          logoId
+        ),
+        createRemoteInlineImage(
+          'https://via.placeholder.com/300x100/0066cc/ffffff?text=Newsletter+Banner',
+          bannerId
+        )
+      ]
+    })
+
+    console.log('✅ Newsletter sent with generated contentIds:', result.id)
+    return result
+  } catch (error) {
+    console.error('❌ Error:', error)
+    throw error
+  }
+}
+
+/**
+ * Example 4: Validating inline image references
+ */
+async function sendEmailWithValidation() {
+  try {
+    const html = `
+      <div>
+        <h1>Product Showcase</h1>
+        <p>Main product: <img src="cid:main-product" alt="Main Product"/></p>
+        <p>Feature highlight: <img src="cid:feature" alt="Feature"/></p>
+        <p>Company logo: <img src="cid:company-logo" alt="Logo"/></p>
+      </div>
+    `
+
+    // Create attachments
+    const attachments = [
+      createRemoteInlineImage(
+        'https://via.placeholder.com/200x200/ff6600/ffffff?text=Product',
+        'main-product'
+      ),
+      createRemoteInlineImage(
+        'https://via.placeholder.com/150x150/28a745/ffffff?text=Feature',
+        'feature'
+      ),
+      createRemoteInlineImage(
+        'https://resend.com/static/sample/logo.png',
+        'company-logo'
+      )
+    ]
+
+    // Validate that all references have corresponding attachments
+    const validation = validateInlineImageReferences(html, attachments)
+    
+    if (!validation.isValid) {
+      console.warn('⚠️ Validation issues found:')
+      if (validation.missingContentIds.length > 0) {
+        console.warn('Missing attachments for:', validation.missingContentIds)
+      }
+      if (validation.unusedContentIds.length > 0) {
+        console.warn('Unused attachments:', validation.unusedContentIds)
+      }
+    } else {
+      console.log('✅ All inline image references are valid')
+    }
+
+    // Extract contentIds from HTML (for debugging)
+    const referencedIds = extractContentIdsFromHtml(html)
+    console.log('ContentIds found in HTML:', referencedIds)
+
+    const result = await inbound.emails.send({
+      from: 'Products <products@yourdomain.com>',
+      to: ['customer@example.com'],
+      subject: 'Product Showcase - Validated Images',
+      html,
+      attachments
+    })
+
+    console.log('✅ Validated email sent:', result.id)
+    return result
+  } catch (error) {
+    console.error('❌ Error:', error)
+    throw error
+  }
+}
+
+/**
+ * Example 5: Handling validation errors gracefully
+ */
+async function demonstrateValidationErrors() {
+  try {
+    console.log('\n🔍 Testing validation utilities...\n')
+
+    // Test contentId validation
+    console.log('Valid contentId "logo-123":', validateContentId('logo-123'))
+    console.log('Invalid contentId (too long):', validateContentId('a'.repeat(130)))
+    console.log('Invalid contentId (special chars):', validateContentId('logo@#$%'))
+
+    // Test content type detection
+    console.log('Content type for logo.png:', getContentTypeFromExtension('logo.png'))
+    console.log('Content type for image.jpg:', getContentTypeFromExtension('image.jpg'))
+    console.log('Content type for unknown.xyz:', getContentTypeFromExtension('unknown.xyz'))
+
+    // Test HTML parsing
+    const testHtml = '<p>Image: <img src="cid:test-image"/> and <img src="cid:another-image"/></p>'
+    console.log('ContentIds in HTML:', extractContentIdsFromHtml(testHtml))
+
+    // Test validation with mismatched references
+    const mismatchedValidation = validateInlineImageReferences(
+      '<p><img src="cid:missing-image"/></p>',
+      [{ contentId: 'unused-image' }]
+    )
+    console.log('Mismatched validation result:', mismatchedValidation)
+
+  } catch (error) {
+    console.error('❌ Validation error:', error)
+  }
+}
+
+/**
+ * Example 6: Error handling with utilities
+ */
+async function demonstrateErrorHandling() {
+  try {
+    // This will throw an error due to invalid contentId
+    createRemoteInlineImage(
+      'https://example.com/image.png',
+      'invalid@contentId', // Invalid characters
+      'image.png'
+    )
+  } catch (error) {
+    console.log('✅ Caught expected error for invalid contentId:', error.message)
+  }
+
+  try {
+    // This will throw an error due to invalid base64
+    createBase64InlineImage(
+      'not-base64-content',
+      'image.png',
+      'valid-id'
+    )
+  } catch (error) {
+    console.log('✅ Caught expected error for invalid base64:', error.message)
+  }
+}
+
+// Example usage
+async function runUtilityExamples() {
+  console.log('🚀 Running Inline Images Utility Examples...\n')
+
+  try {
+    // Run examples
+    await sendEmailWithUtilityRemoteImage()
+    await sendEmailWithUtilityBase64Image()
+    await sendEmailWithGeneratedContentIds()
+    await sendEmailWithValidation()
+    
+    // Demonstrate validation utilities
+    await demonstrateValidationErrors()
+    await demonstrateErrorHandling()
+
+    console.log('\n✅ All utility examples completed successfully!')
+  } catch (error) {
+    console.error('\n❌ Utility examples failed:', error)
+  }
+}
+
+// Export functions for individual use
+export {
+  sendEmailWithUtilityRemoteImage,
+  sendEmailWithUtilityBase64Image,
+  sendEmailWithGeneratedContentIds,
+  sendEmailWithValidation,
+  demonstrateValidationErrors,
+  demonstrateErrorHandling
+}
+
+// Run examples if this file is executed directly
+if (require.main === module) {
+  runUtilityExamples()
+}

--- a/@inboundemail/sdk/examples/inline-images.ts
+++ b/@inboundemail/sdk/examples/inline-images.ts
@@ -1,0 +1,366 @@
+/**
+ * Inline Images Examples - Inbound Email SDK
+ * 
+ * This example demonstrates how to embed inline images in emails using the Inbound Email SDK.
+ * Inline images are embedded as attachments with contentId references that can be used in HTML.
+ * 
+ * Based on Resend's inline images documentation:
+ * https://resend.com/docs/send/inline-images
+ */
+
+import { Inbound } from '../src/index'
+import * as fs from 'fs'
+import * as path from 'path'
+
+// Initialize the Inbound client
+const inbound = new Inbound('your-api-key-here')
+
+/**
+ * Example 1: Remote Inline Image
+ * 
+ * Send an email with an inline image loaded from a remote URL.
+ * The image is referenced in the HTML using cid: prefix.
+ */
+async function sendEmailWithRemoteInlineImage() {
+  try {
+    const result = await inbound.emails.send({
+      from: 'Acme <onboarding@yourdomain.com>',
+      to: ['recipient@example.com'],
+      subject: 'Thank you for contacting us',
+      html: '<p>Here is our <img src="cid:logo-image"/> inline logo</p>',
+      attachments: [
+        {
+          path: 'https://resend.com/static/sample/logo.png',
+          filename: 'logo.png',
+          contentId: 'logo-image',
+        },
+      ],
+    })
+
+    console.log('✅ Email sent with remote inline image:', result.id)
+    return result
+  } catch (error) {
+    console.error('❌ Failed to send email with remote inline image:', error)
+    throw error
+  }
+}
+
+/**
+ * Example 2: Local Inline Image
+ * 
+ * Send an email with an inline image loaded from a local file.
+ * The image content is base64 encoded before sending.
+ */
+async function sendEmailWithLocalInlineImage() {
+  try {
+    // Read the local image file and convert to base64
+    const imagePath = path.join(__dirname, 'assets', 'logo.png')
+    const imageBuffer = fs.readFileSync(imagePath)
+    const imageBase64 = imageBuffer.toString('base64')
+
+    const result = await inbound.emails.send({
+      from: 'Acme <onboarding@yourdomain.com>',
+      to: ['recipient@example.com'],
+      subject: 'Thank you for contacting us',
+      html: '<p>Here is our <img src="cid:logo-image"/> inline logo</p>',
+      attachments: [
+        {
+          content: imageBase64,
+          filename: 'logo.png',
+          contentType: 'image/png',
+          contentId: 'logo-image',
+        },
+      ],
+    })
+
+    console.log('✅ Email sent with local inline image:', result.id)
+    return result
+  } catch (error) {
+    console.error('❌ Failed to send email with local inline image:', error)
+    throw error
+  }
+}
+
+/**
+ * Example 3: Multiple Inline Images
+ * 
+ * Send an email with multiple inline images, each with unique contentId.
+ */
+async function sendEmailWithMultipleInlineImages() {
+  try {
+    const result = await inbound.emails.send({
+      from: 'Acme <onboarding@yourdomain.com>',
+      to: ['recipient@example.com'],
+      subject: 'Multiple inline images example',
+      html: `
+        <div>
+          <h1>Welcome to Acme!</h1>
+          <p>Here's our logo: <img src="cid:logo" alt="Acme Logo" style="width: 100px;"/></p>
+          <p>And here's a banner: <img src="cid:banner" alt="Banner" style="width: 300px;"/></p>
+          <p>Best regards,<br/>The Acme Team</p>
+        </div>
+      `,
+      attachments: [
+        {
+          path: 'https://resend.com/static/sample/logo.png',
+          filename: 'logo.png',
+          contentType: 'image/png',
+          contentId: 'logo',
+        },
+        {
+          path: 'https://via.placeholder.com/300x100/0066cc/ffffff?text=Acme+Banner',
+          filename: 'banner.png',
+          contentType: 'image/png',
+          contentId: 'banner',
+        },
+      ],
+    })
+
+    console.log('✅ Email sent with multiple inline images:', result.id)
+    return result
+  } catch (error) {
+    console.error('❌ Failed to send email with multiple inline images:', error)
+    throw error
+  }
+}
+
+/**
+ * Example 4: Mixed Attachments (Regular + Inline)
+ * 
+ * Send an email with both regular attachments and inline images.
+ * Regular attachments don't have contentId, while inline images do.
+ */
+async function sendEmailWithMixedAttachments() {
+  try {
+    const result = await inbound.emails.send({
+      from: 'Acme <onboarding@yourdomain.com>',
+      to: ['recipient@example.com'],
+      subject: 'Mixed attachments example',
+      html: `
+        <div>
+          <h1>Invoice Attached</h1>
+          <p>Please find your invoice attached to this email.</p>
+          <p>Our company logo: <img src="cid:company-logo" alt="Company Logo" style="width: 80px;"/></p>
+          <p>Thank you for your business!</p>
+        </div>
+      `,
+      attachments: [
+        // Regular attachment (will appear in email client's attachment list)
+        {
+          path: 'https://example.com/invoice.pdf',
+          filename: 'invoice-2024.pdf',
+          contentType: 'application/pdf',
+          // No contentId = regular attachment
+        },
+        // Inline image (embedded in email body)
+        {
+          path: 'https://resend.com/static/sample/logo.png',
+          filename: 'logo.png',
+          contentType: 'image/png',
+          contentId: 'company-logo', // contentId = inline image
+        },
+      ],
+    })
+
+    console.log('✅ Email sent with mixed attachments:', result.id)
+    return result
+  } catch (error) {
+    console.error('❌ Failed to send email with mixed attachments:', error)
+    throw error
+  }
+}
+
+/**
+ * Example 5: Inline Image in Email Reply
+ * 
+ * Reply to an email with an inline image.
+ */
+async function replyWithInlineImage(originalEmailId: string) {
+  try {
+    const result = await inbound.emails.reply(originalEmailId, {
+      from: 'Support <support@yourdomain.com>',
+      html: `
+        <p>Thank you for your inquiry!</p>
+        <p>Here's our support team signature:</p>
+        <img src="cid:support-signature" alt="Support Team" style="width: 200px;"/>
+        <p>Best regards,<br/>Support Team</p>
+      `,
+      attachments: [
+        {
+          path: 'https://via.placeholder.com/200x50/28a745/ffffff?text=Support+Team',
+          filename: 'support-signature.png',
+          contentType: 'image/png',
+          contentId: 'support-signature',
+        },
+      ],
+    })
+
+    console.log('✅ Reply sent with inline image:', result.id)
+    return result
+  } catch (error) {
+    console.error('❌ Failed to send reply with inline image:', error)
+    throw error
+  }
+}
+
+/**
+ * Example 6: Newsletter with Inline Images
+ * 
+ * Send a newsletter-style email with multiple inline images and proper HTML structure.
+ */
+async function sendNewsletterWithInlineImages() {
+  try {
+    const result = await inbound.emails.send({
+      from: 'Acme Newsletter <newsletter@yourdomain.com>',
+      to: ['subscriber@example.com'],
+      subject: 'Acme Monthly Newsletter - January 2024',
+      html: `
+        <!DOCTYPE html>
+        <html>
+        <head>
+          <meta charset="utf-8">
+          <meta name="viewport" content="width=device-width, initial-scale=1">
+          <title>Acme Newsletter</title>
+          <style>
+            body { font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto; }
+            .header { text-align: center; padding: 20px 0; }
+            .content { padding: 20px; }
+            .footer { text-align: center; padding: 20px; background: #f8f9fa; }
+            img { max-width: 100%; height: auto; }
+          </style>
+        </head>
+        <body>
+          <div class="header">
+            <img src="cid:newsletter-header" alt="Acme Newsletter" />
+          </div>
+          <div class="content">
+            <h1>Welcome to our January Newsletter!</h1>
+            <p>We're excited to share our latest updates with you.</p>
+            
+            <h2>Product Spotlight</h2>
+            <img src="cid:product-image" alt="Featured Product" style="float: left; margin: 0 20px 20px 0; width: 200px;" />
+            <p>Check out our latest product launch! This amazing widget will revolutionize your workflow.</p>
+            <div style="clear: both;"></div>
+            
+            <h2>Company News</h2>
+            <p>We're growing fast and have some exciting announcements:</p>
+            <ul>
+              <li>New office opening in San Francisco</li>
+              <li>Partnership with TechCorp</li>
+              <li>Award for Best Innovation 2024</li>
+            </ul>
+          </div>
+          <div class="footer">
+            <img src="cid:company-logo" alt="Acme" style="width: 100px;" />
+            <p>© 2024 Acme Corp. All rights reserved.</p>
+            <p><a href="#">Unsubscribe</a> | <a href="#">Update Preferences</a></p>
+          </div>
+        </body>
+        </html>
+      `,
+      attachments: [
+        {
+          path: 'https://via.placeholder.com/600x150/0066cc/ffffff?text=Acme+Newsletter',
+          filename: 'newsletter-header.png',
+          contentType: 'image/png',
+          contentId: 'newsletter-header',
+        },
+        {
+          path: 'https://via.placeholder.com/200x200/28a745/ffffff?text=Product',
+          filename: 'product.png',
+          contentType: 'image/png',
+          contentId: 'product-image',
+        },
+        {
+          path: 'https://resend.com/static/sample/logo.png',
+          filename: 'logo.png',
+          contentType: 'image/png',
+          contentId: 'company-logo',
+        },
+      ],
+    })
+
+    console.log('✅ Newsletter sent with inline images:', result.id)
+    return result
+  } catch (error) {
+    console.error('❌ Failed to send newsletter with inline images:', error)
+    throw error
+  }
+}
+
+/**
+ * Utility function to convert local image to base64
+ */
+export function imageToBase64(imagePath: string): string {
+  try {
+    const imageBuffer = fs.readFileSync(imagePath)
+    return imageBuffer.toString('base64')
+  } catch (error) {
+    console.error('❌ Failed to read image file:', error)
+    throw new Error(`Failed to read image file: ${imagePath}`)
+  }
+}
+
+/**
+ * Utility function to get content type from file extension
+ */
+export function getContentTypeFromExtension(filename: string): string {
+  const ext = path.extname(filename).toLowerCase()
+  const contentTypes: Record<string, string> = {
+    '.png': 'image/png',
+    '.jpg': 'image/jpeg',
+    '.jpeg': 'image/jpeg',
+    '.gif': 'image/gif',
+    '.webp': 'image/webp',
+    '.svg': 'image/svg+xml',
+    '.bmp': 'image/bmp',
+    '.ico': 'image/x-icon',
+  }
+  return contentTypes[ext] || 'application/octet-stream'
+}
+
+// Example usage
+async function runExamples() {
+  console.log('🚀 Running Inline Images Examples...\n')
+
+  try {
+    // Example 1: Remote inline image
+    console.log('1️⃣ Sending email with remote inline image...')
+    await sendEmailWithRemoteInlineImage()
+
+    // Example 2: Local inline image (commented out as it requires local file)
+    // console.log('2️⃣ Sending email with local inline image...')
+    // await sendEmailWithLocalInlineImage()
+
+    // Example 3: Multiple inline images
+    console.log('3️⃣ Sending email with multiple inline images...')
+    await sendEmailWithMultipleInlineImages()
+
+    // Example 4: Mixed attachments
+    console.log('4️⃣ Sending email with mixed attachments...')
+    await sendEmailWithMixedAttachments()
+
+    // Example 6: Newsletter
+    console.log('6️⃣ Sending newsletter with inline images...')
+    await sendNewsletterWithInlineImages()
+
+    console.log('\n✅ All examples completed successfully!')
+  } catch (error) {
+    console.error('\n❌ Examples failed:', error)
+  }
+}
+
+// Export all functions for individual use
+export {
+  sendEmailWithRemoteInlineImage,
+  sendEmailWithLocalInlineImage,
+  sendEmailWithMultipleInlineImages,
+  sendEmailWithMixedAttachments,
+  replyWithInlineImage,
+  sendNewsletterWithInlineImages,
+}
+
+// Run examples if this file is executed directly
+if (require.main === module) {
+  runExamples()
+}

--- a/@inboundemail/sdk/src/types.ts
+++ b/@inboundemail/sdk/src/types.ts
@@ -432,10 +432,11 @@ export interface PostEmailsRequest {
   text?: string
   headers?: Record<string, string>
   attachments?: Array<{
-    content: string // Base64 encoded
+    content?: string // Base64 encoded
     filename: string
     path?: string
     contentType?: string  // Changed from content_type to match Resend
+    contentId?: string    // For inline images (CID references)
   }>
   tags?: Array<{  // Added tags support like Resend
     name: string
@@ -474,10 +475,11 @@ export interface PostEmailReplyRequest {
   replyTo?: string | string[]  // Added replyTo support
   headers?: Record<string, string>
   attachments?: Array<{
-    content: string
+    content?: string
     filename: string
     path?: string
     contentType?: string  // Changed from content_type to match Resend
+    contentId?: string    // For inline images (CID references)
   }>
   tags?: Array<{  // Added tags support like Resend
     name: string

--- a/@inboundemail/sdk/src/utils.ts
+++ b/@inboundemail/sdk/src/utils.ts
@@ -24,4 +24,187 @@ export function buildQueryString(params: Record<string, any>): string {
   
   const queryString = searchParams.toString()
   return queryString ? `?${queryString}` : ''
+}
+
+/**
+ * Inline Image Utilities
+ */
+
+/**
+ * Get content type from file extension
+ */
+export function getContentTypeFromExtension(filename: string): string {
+  const ext = filename.toLowerCase().split('.').pop()
+  const contentTypes: Record<string, string> = {
+    'png': 'image/png',
+    'jpg': 'image/jpeg',
+    'jpeg': 'image/jpeg',
+    'gif': 'image/gif',
+    'webp': 'image/webp',
+    'svg': 'image/svg+xml',
+    'bmp': 'image/bmp',
+    'ico': 'image/x-icon',
+    'tiff': 'image/tiff',
+    'tif': 'image/tiff'
+  }
+  return contentTypes[ext || ''] || 'application/octet-stream'
+}
+
+/**
+ * Validate contentId for inline images
+ * ContentId should be less than 128 characters and contain valid characters
+ */
+export function validateContentId(contentId: string): boolean {
+  if (!contentId || contentId.length === 0) {
+    return false
+  }
+  
+  if (contentId.length > 127) { // Less than 128 as per Resend docs
+    return false
+  }
+  
+  // ContentId should not contain special characters that might break email parsing
+  // Allow alphanumeric, hyphens, underscores, and periods
+  const validContentIdRegex = /^[a-zA-Z0-9._-]+$/
+  return validContentIdRegex.test(contentId)
+}
+
+/**
+ * Generate a unique contentId for inline images
+ */
+export function generateContentId(prefix?: string): string {
+  const timestamp = Date.now()
+  const random = Math.random().toString(36).substring(2, 8)
+  const baseId = `${timestamp}-${random}`
+  
+  if (prefix) {
+    return `${prefix}-${baseId}`
+  }
+  
+  return baseId
+}
+
+/**
+ * Check if a string is base64 encoded
+ */
+export function isBase64(str: string): boolean {
+  if (!str || str.length === 0) {
+    return false
+  }
+  
+  try {
+    // Check if string matches base64 pattern
+    const base64Regex = /^[A-Za-z0-9+/]*={0,2}$/
+    if (!base64Regex.test(str)) {
+      return false
+    }
+    
+    // Additional check: base64 length should be multiple of 4
+    return str.length % 4 === 0
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Create an inline image attachment object from a remote URL
+ */
+export function createRemoteInlineImage(
+  url: string,
+  contentId: string,
+  filename?: string,
+  contentType?: string
+): { path: string; filename: string; contentId: string; contentType?: string } {
+  if (!validateContentId(contentId)) {
+    throw new Error(`Invalid contentId: ${contentId}. Must be less than 128 characters and contain only alphanumeric characters, hyphens, underscores, and periods.`)
+  }
+  
+  // Extract filename from URL if not provided
+  const inferredFilename = filename || url.split('/').pop()?.split('?')[0] || 'image'
+  
+  // Infer content type from filename if not provided
+  const inferredContentType = contentType || getContentTypeFromExtension(inferredFilename)
+  
+  return {
+    path: url,
+    filename: inferredFilename,
+    contentId,
+    ...(inferredContentType !== 'application/octet-stream' && { contentType: inferredContentType })
+  }
+}
+
+/**
+ * Create an inline image attachment object from base64 content
+ */
+export function createBase64InlineImage(
+  base64Content: string,
+  filename: string,
+  contentId: string,
+  contentType?: string
+): { content: string; filename: string; contentId: string; contentType: string } {
+  if (!validateContentId(contentId)) {
+    throw new Error(`Invalid contentId: ${contentId}. Must be less than 128 characters and contain only alphanumeric characters, hyphens, underscores, and periods.`)
+  }
+  
+  if (!isBase64(base64Content)) {
+    throw new Error('Content must be valid base64 encoded data')
+  }
+  
+  // Infer content type from filename if not provided
+  const inferredContentType = contentType || getContentTypeFromExtension(filename)
+  
+  return {
+    content: base64Content,
+    filename,
+    contentId,
+    contentType: inferredContentType
+  }
+}
+
+/**
+ * Extract all contentIds referenced in HTML content
+ * Finds all cid: references in img src attributes
+ */
+export function extractContentIdsFromHtml(html: string): string[] {
+  const contentIds: string[] = []
+  
+  // Match img tags with cid: src attributes
+  const cidRegex = /<img[^>]+src=["']cid:([^"']+)["'][^>]*>/gi
+  let match
+  
+  while ((match = cidRegex.exec(html)) !== null) {
+    const contentId = match[1]
+    if (contentId && !contentIds.includes(contentId)) {
+      contentIds.push(contentId)
+    }
+  }
+  
+  return contentIds
+}
+
+/**
+ * Validate that all contentIds in HTML have corresponding attachments
+ */
+export function validateInlineImageReferences(
+  html: string,
+  attachments: Array<{ contentId?: string }> = []
+): { isValid: boolean; missingContentIds: string[]; unusedContentIds: string[] } {
+  const referencedContentIds = extractContentIdsFromHtml(html)
+  const attachmentContentIds = attachments
+    .filter(att => att.contentId)
+    .map(att => att.contentId!)
+  
+  const missingContentIds = referencedContentIds.filter(
+    id => !attachmentContentIds.includes(id)
+  )
+  
+  const unusedContentIds = attachmentContentIds.filter(
+    id => !referencedContentIds.includes(id)
+  )
+  
+  return {
+    isValid: missingContentIds.length === 0,
+    missingContentIds,
+    unusedContentIds
+  }
 } 


### PR DESCRIPTION
Add support for embedding inline images in emails by introducing `contentId` for attachments.

This PR introduces the `contentId` field to email attachments, enabling images to be referenced directly within the HTML body using `cid:` URLs. It includes comprehensive examples for both remote and local (base64) inline images, along with utility functions for easier management and validation, aligning the SDK with Resend's inline image capabilities.

---
<a href="https://cursor.com/background-agent?bcId=bc-b64e3e14-f9a3-449d-9cc6-c06549c033c3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b64e3e14-f9a3-449d-9cc6-c06549c033c3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

