### PR TITLE
Investigate email ID mismatch on logs page

### DIFF
--- a/app/(main)/logs/[id]/page.tsx
+++ b/app/(main)/logs/[id]/page.tsx
@@ -189,6 +189,11 @@ export default async function LogDetailPage({ params }: { params: Promise<{ id: 
       }
     })
 
+    // Defensive check: emailId should never be null since it's NOT NULL in schema
+    if (!row.emailId) {
+      console.error(`[CRITICAL] Email ID missing for structured email ${row.id}. This indicates a data integrity issue.`)
+    }
+
     inboundDetails = {
       id: row.id,
       emailId: row.emailId, // The actual emailId used by the API for replies
@@ -283,6 +288,12 @@ export default async function LogDetailPage({ params }: { params: Promise<{ id: 
     }
 
     const row = details[0]
+    
+    // Defensive check: id should never be null since it's the primary key
+    if (!row.id) {
+      console.error(`[CRITICAL] Sent email ID missing. This indicates a data integrity issue.`)
+    }
+    
     const parseJSON = (s: string | null) => { try { return s ? JSON.parse(s) : [] } catch { return [] } }
     const to = parseJSON(row.to)
     const cc = parseJSON(row.cc)
@@ -565,7 +576,19 @@ export default async function LogDetailPage({ params }: { params: Promise<{ id: 
                   <div>
                     <span className="text-muted-foreground">{isInbound ? "Inbound Email ID" : "Outbound Email ID"}:</span>
                     <div className="mt-1">
-                      <ClickableId id={isInbound ? (inboundDetails?.emailId || id) : (outboundDetails?.id || id)} />
+                      {isInbound ? (
+                        inboundDetails?.emailId ? (
+                          <ClickableId id={inboundDetails.emailId} />
+                        ) : (
+                          <span className="text-destructive text-xs">Data integrity error - missing emailId</span>
+                        )
+                      ) : (
+                        outboundDetails?.id ? (
+                          <ClickableId id={outboundDetails.id} />
+                        ) : (
+                          <span className="text-destructive text-xs">Data integrity error - missing id</span>
+                        )
+                      )}
                     </div>
                   </div>
                   {((isInbound && inboundDetails?.messageId) || (outboundDetails && 'id' in outboundDetails)) && (


### PR DESCRIPTION
Fix email ID displayed on the logs page to be compatible with the reply API.

The logs page was incorrectly displaying `structuredEmails.id` (the internal primary key) instead of `structuredEmails.emailId` (the foreign key reference used by the reply API). This prevented users from successfully replying to emails using the ID shown in the UI. This PR updates the logs page to consistently show the `emailId` that the API expects.

---
<a href="https://cursor.com/background-agent?bcId=bc-830e3f8e-780e-417b-8c8d-f8c493da221f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-830e3f8e-780e-417b-8c8d-f8c493da221f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Inbound messages now use the correct email identifier for display and actions (instead of the message id).
  * Resend dialog targets the correct inbound identifier.
  * Outbound messages consistently use their own identifier for display and actions.
  * Added defensive checks and error logging when identifiers are missing, with sensible fallbacks in the UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->