### PR TITLE
Fix homepage query field name

### DIFF
--- a/app/actions/homepage.ts
+++ b/app/actions/homepage.ts
@@ -3,7 +3,7 @@ import { basehub } from "basehub";
 export async function getHomepageContent() {
   try {
     const selection = {
-      homepage: {
+      homePage: {
         _title: true,
         heroPrimaryText: true,
         heroSublineText: true,
@@ -15,7 +15,7 @@ export async function getHomepageContent() {
 
     return {
       success: true,
-      data: data.homepage,
+      data: data.homePage,
     };
   } catch (error) {
     console.error("Error fetching homepage content:", error);

--- a/basehub-types.d.ts
+++ b/basehub-types.d.ts
@@ -338,7 +338,7 @@ export interface Query {
     _structure: Scalars['JSON']
     _sys: RepoSys
     blogPosts: BlogPosts
-    homepage: Homepage
+    homePage: Homepage
     __typename: 'Query'
 }
 
@@ -1047,7 +1047,7 @@ export interface QueryGenqlSelection{
     withTypeOptions?: (Scalars['Boolean'] | null)} } | boolean | number
     _sys?: RepoSysGenqlSelection
     blogPosts?: BlogPostsGenqlSelection
-    homepage?: HomepageGenqlSelection
+    homePage?: HomepageGenqlSelection
     __typename?: boolean | number
     __fragmentOn?: "Query"
 }


### PR DESCRIPTION
Fix GraphQL error by updating `homepage` field to `homePage` in query and types to match BaseHub schema.

The BaseHub GraphQL schema expects the `homePage` field (camelCase), but the application's query and local type definitions were using `homepage` (lowercase), leading to a GraphQL query error. This PR aligns the field names to resolve the issue.

---
<a href="https://cursor.com/background-agent?bcId=bc-2f421640-de5c-47fe-9348-68dc5bfc2997"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2f421640-de5c-47fe-9348-68dc5bfc2997"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Breaking Changes
  * Renamed the homepage data field to homePage across queries and public types. Update any integrations, queries, or configurations that reference the old field name.

* Refactor
  * Aligned internal data mapping to use homePage for consistency with updated schema. No functional changes to behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->