### PR TITLE
Investigate api key display inconsistency

### DIFF
--- a/app/(main)/api-keys/page.tsx
+++ b/app/(main)/api-keys/page.tsx
@@ -321,7 +321,7 @@ export default function ApiKeysPage() {
 
                       <div className="flex items-center gap-2">
                         <span className="text-xs opacity-60">
-                          Key: {apiKey.prefix ? `${apiKey.prefix}_` : ''}***{apiKey.start}
+                          Key: {apiKey.prefix || ''}***{apiKey.start}
                         </span>
                         {apiKey.remaining !== null && (
                           <>


### PR DESCRIPTION
Remove the incorrect underscore from the API key preview display.

The API key preview in the list view was incorrectly adding an underscore between the prefix and the masked key, causing an inconsistency with the actual API key format which does not include this underscore.

---
<a href="https://cursor.com/background-agent?bcId=bc-311958a0-5ded-4971-9c2c-50cb4d68074e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-311958a0-5ded-4971-9c2c-50cb4d68074e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected API key display formatting on the API Keys page by removing an unnecessary underscore between the prefix and start of the key. Keys now appear as “Key: {prefix}{start}” when a prefix exists.
  * Improves readability and reduces confusion when copying or referencing keys, ensuring a more consistent and polished presentation without altering underlying functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->