### PR TITLE
Fix endpoint not showing in domain dropdown

### DIFF
--- a/app/(main)/emails/[id]/page.tsx
+++ b/app/(main)/emails/[id]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useSession } from "@/lib/auth/auth-client";
 import { useParams, useRouter } from "next/navigation";
 import Link from "next/link";
@@ -155,8 +155,11 @@ export default function DomainDetailPage() {
     gcTime: 10 * 60 * 1000, // 10 minutes
   });
 
-  const { data: userEndpoints = [], isLoading: isEndpointsLoading } =
-    useEndpointsQuery();
+  const { 
+    data: userEndpoints = [], 
+    isLoading: isEndpointsLoading, 
+    refetch: refetchEndpoints 
+  } = useEndpointsQuery();
 
   // Get auth recommendations for verified domains
   const {
@@ -216,12 +219,24 @@ export default function DomainDetailPage() {
   // Zone file generation state
   const [isGeneratingZoneFile, setIsGeneratingZoneFile] = useState(false);
 
+  // Refetch endpoints when navigating to this page to ensure fresh data
+  useEffect(() => {
+    if (domainId) {
+      // Small delay to ensure any pending endpoint creations are completed
+      const timer = setTimeout(() => {
+        refetchEndpoints();
+      }, 100);
+      
+      return () => clearTimeout(timer);
+    }
+  }, [domainId, refetchEndpoints]);
+
   // Set catch-all endpoint ID when data loads
-  useState(() => {
+  useEffect(() => {
     if (domainDetailsData?.catchAllEndpointId) {
       setCatchAllEndpointId(domainDetailsData.catchAllEndpointId);
     }
-  });
+  }, [domainDetailsData?.catchAllEndpointId]);
 
   // Get email addresses from the query result
   const emailAddresses = emailAddressesData?.data || [];

--- a/features/endpoints/hooks/useEndpointsQuery.ts
+++ b/features/endpoints/hooks/useEndpointsQuery.ts
@@ -25,7 +25,8 @@ export const useEndpointsQuery = (sortBy?: 'newest' | 'oldest') => {
   const endpointsQuery = useQuery({
     queryKey: ['endpoints', sortBy],
     queryFn: () => fetchEndpoints(sortBy),
-    staleTime: 5 * 60 * 1000, // 5 minutes
+    staleTime: 30 * 1000, // 30 seconds (reduced from 5 minutes for better UX)
+    refetchOnWindowFocus: true, // Refetch when user returns to tab/page
   })
 
   // Check for migration needs when the query succeeds and returns empty results


### PR DESCRIPTION
Refetch endpoints on domain page load and reduce stale time to ensure newly added endpoints appear immediately in the dropdown.

Previously, `useEndpointsQuery` had a 5-minute `staleTime` and lacked a mechanism to refetch data when navigating to the domain detail page. This meant that endpoints created on the endpoints page would not appear in the domain's address dropdown until a manual refresh or after the stale time expired.

---
<a href="https://cursor.com/background-agent?bcId=bc-95de1ea5-58c3-4704-8320-4eaa8fbc10e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-95de1ea5-58c3-4704-8320-4eaa8fbc10e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Endpoints now refresh automatically after navigating to the email details page, ensuring the latest data is shown.
  - Data refreshes when returning to the browser tab, keeping information up to date without manual reload.
  - Faster update cadence with shorter caching, reducing the chance of seeing stale endpoint data.
  - Foundation added for surfacing migration status in the UI, enabling clearer visibility into ongoing migrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->