### PR TITLE
Fix sent email record and message ids

### DIFF
--- a/app/(main)/logs/[id]/page.tsx
+++ b/app/(main)/logs/[id]/page.tsx
@@ -85,7 +85,7 @@ export default async function LogDetailPage({ params }: { params: Promise<{ id: 
 
   // Fetch rich details based on type
   let inboundDetails: (GetMailByIdResponse & { deliveries?: Array<any> }) | null = null
-  let outboundDetails: (GetEmailByIdResponse & { provider?: string; status?: string; failureReason?: string | null; providerResponse?: any }) | null = null
+  let outboundDetails: (GetEmailByIdResponse & { messageId?: string | null; provider?: string; status?: string; failureReason?: string | null; providerResponse?: any }) | null = null
 
   if (type === 'inbound') {
     // Get full inbound email details by reusing the same projection as the API
@@ -264,6 +264,7 @@ export default async function LogDetailPage({ params }: { params: Promise<{ id: 
     const details = await db
       .select({
         id: sentEmails.id,
+        messageId: sentEmails.messageId,
         from: sentEmails.from,
         to: sentEmails.to,
         cc: sentEmails.cc,
@@ -305,6 +306,7 @@ export default async function LogDetailPage({ params }: { params: Promise<{ id: 
     outboundDetails = {
       object: 'email',
       id: row.id,
+      messageId: row.messageId,
       to,
       from: row.from,
       created_at: row.createdAt?.toISOString() || new Date().toISOString(),
@@ -599,11 +601,11 @@ export default async function LogDetailPage({ params }: { params: Promise<{ id: 
                       </div>
                     </div>
                   )}
-                  {((isInbound && inboundDetails?.messageId) || (outboundDetails && 'id' in outboundDetails)) && (
+                  {((isInbound && inboundDetails?.messageId) || (outboundDetails && 'messageId' in outboundDetails)) && (
                     <div>
                       <span className="text-muted-foreground">Message ID (RFC 822):</span>
                       <div className="mt-1">
-                        <ClickableId id={isInbound ? inboundDetails?.messageId || '' : outboundDetails?.id || ''} preview={true} />
+                        <ClickableId id={isInbound ? inboundDetails?.messageId || '' : outboundDetails?.messageId || ''} preview={true} />
                       </div>
                     </div>
                   )}

--- a/app/api/cron/process-scheduled-emails/route.ts
+++ b/app/api/cron/process-scheduled-emails/route.ts
@@ -173,7 +173,7 @@ export async function GET(request: NextRequest) {
                 })
 
                 // Create sent email record first (for tracking)
-                const sentEmailId = nanoid()
+                const sentEmailId = `outbnd_${nanoid()}`
                 const sentEmailData = {
                     id: sentEmailId,
                     from: scheduledEmail.fromAddress,

--- a/app/api/v2/emails/[id]/reply-10-01-25/route.ts
+++ b/app/api/v2/emails/[id]/reply-10-01-25/route.ts
@@ -292,7 +292,7 @@ async function handleSimpleReply(
   }
 
   // Create basic email record
-  const replyEmailId = nanoid();
+  const replyEmailId = `outbnd_${nanoid()}`;
   const messageId = `${replyEmailId}@${fromDomain}`;
 
   console.log("💾 Creating simple email record:", replyEmailId);
@@ -847,7 +847,7 @@ export async function POST(
     }
 
     // Create sent email record
-    const replyEmailId = nanoid();
+    const replyEmailId = `outbnd_${nanoid()}`;
 
     // Check if a custom Message-ID is provided (case-insensitive)
     let messageId = `${replyEmailId}@${fromDomain}`;

--- a/app/api/v2/emails/[id]/reply/route.ts
+++ b/app/api/v2/emails/[id]/reply/route.ts
@@ -612,7 +612,7 @@ export async function POST(
     }
 
     // Create email record
-    const replyEmailId = nanoid();
+    const replyEmailId = `outbnd_${nanoid()}`;
     const messageId = `${replyEmailId}@${fromDomain}`;
 
     // Build threading headers using exact original Message-ID

--- a/app/api/v2/emails/route.ts
+++ b/app/api/v2/emails/route.ts
@@ -255,7 +255,7 @@ export async function POST(request: NextRequest) {
         }
 
         // Create sent email record
-        const emailId = nanoid()
+        const emailId = `outbnd_${nanoid()}`
         console.log('💾 Creating sent email record:', emailId)
         
         const sentEmailRecord = await db.insert(sentEmails).values({


### PR DESCRIPTION
Prefix all outbound email record IDs with `outbnd_` and display the correct SES `messageId` on the log detail page to align with tracking requirements.

This PR resolves two issues:
1.  The `Record ID` for sent emails was missing the `outbnd_` prefix, making it difficult to differentiate.
2.  The `Message ID (RFC 822)` field on the log detail page was incorrectly showing the `Record ID` instead of the actual SES message ID from the database.

---
Linear Issue: [ENG-12](https://linear.app/inbound/issue/ENG-12/sent-emails-in-the-email-flow-dont-have-outbnd-or-the-correct-message)

<a href="https://cursor.com/background-agent?bcId=bc-c68902a6-8b9f-408c-b931-58ac582f62b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c68902a6-8b9f-408c-b931-58ac582f62b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Outbound log entries now display and link using the Message-ID for clearer tracking.
* **Chores**
  * Standardized the format of generated IDs for outgoing emails (including replies) to use a consistent, prefixed pattern, improving traceability and threading across the app.
  * Updated outbound views to rely on Message-ID for navigation and display, without changing inbound behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->