### PR TITLE
Fix email filter domain population and refresh animation

### DIFF
--- a/app/(main)/logs/page.tsx
+++ b/app/(main)/logs/page.tsx
@@ -376,10 +376,7 @@ export default function LogsPage() {
 
             <Select 
               value={domainFilter} 
-              onValueChange={(value) => {
-                // Allow direct switching between domains without clearing first
-                setDomainFilter(value)
-              }}
+              onValueChange={setDomainFilter}
               disabled={domainsLoading}
             >
               <SelectTrigger className="w-[140px] h-9 rounded-xl">
@@ -390,7 +387,10 @@ export default function LogsPage() {
                 {domainsLoading ? (
                   <SelectItem value="loading" disabled>
                     <div className="flex items-center gap-2 text-muted-foreground">
-                      <div className="w-3 h-3 border border-muted-foreground/30 border-t-muted-foreground rounded-full animate-spin" />
+                      <div 
+                        className="w-3 h-3 border border-muted-foreground/30 border-t-muted-foreground rounded-full animate-spin" 
+                        aria-label="Loading domains"
+                      />
                       Loading domains...
                     </div>
                   </SelectItem>


### PR DESCRIPTION
Enhance email flow page domain filtering by populating from all available domains and enabling direct switching, and correct the refresh icon's rotation.

Previously, the domain filter only displayed domains present in the current email log results, making it impossible to filter by newly added domains until emails were received. Additionally, users had to clear the current domain filter before selecting a new one. This PR resolves both issues for a smoother user experience.

---
<a href="https://cursor.com/background-agent?bcId=bc-cac928b5-b79b-4958-ac02-cdfe2c81843a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-cac928b5-b79b-4958-ac02-cdfe2c81843a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Domain filter now uses the full available domain set, shows an "All Domains" option, and displays explicit loading / error / no-domains items; shows a “more domains” indicator when total exceeds fetch limit.
* **Bug Fixes**
  * Domain selection no longer clears other active filters; domain dropdown is disabled while domains load and preserves existing filters during changes.
* **Style**
  * Refresh icon animation updated to rotate counter‑clockwise.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->