### PR TITLE
Add outbound email sending hyperlink

### DIFF
--- a/components/landing/solution.tsx
+++ b/components/landing/solution.tsx
@@ -37,7 +37,7 @@ export function Solution() {
                         </div>
                         <h3 className="text-xl font-semibold text-foreground tracking-tight">Transactional Email Sending</h3>
                         <p className="text-muted-foreground text-sm leading-relaxed tracking-normal">
-                            Deliver confirmations, notifications, and alerts with a reliable sending API. Fully compatible with popular email services.
+                            Deliver confirmations, notifications, and alerts with a reliable sending API. Fully compatible with popular email services. Also called outbound email sending, <a href="https://x.com/itswilsonhou/status/1981841420534362281" target="_blank" rel="noopener noreferrer" className="text-primary hover:underline">wilson</a>.
                         </p>
                         <ul className="text-sm text-muted-foreground space-y-1 tracking-normal">
                             <li>• High deliverability rates</li>


### PR DESCRIPTION
Add "Also called outbound email sending, wilson" with a link to a tweet on the landing page to fulfill a user request.

---
<a href="https://cursor.com/background-agent?bcId=bc-a17d4ad1-c15b-457c-8a56-18e5d738c5ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a17d4ad1-c15b-457c-8a56-18e5d738c5ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Enhanced Transactional Email Sending description with clarifying text about outbound email sending functionality and added external reference link.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-24 21:58:50 UTC

<h3>Greptile Summary</h3>


Added a hyperlinked reference to "outbound email sending" with a humorous reference to "wilson" linking to an external tweet in the Transactional Email Sending section of the landing page.

Key changes:
- Added text "Also called outbound email sending, wilson" with proper link attributes (`target="_blank"`, `rel="noopener noreferrer"`)
- Applied appropriate styling classes (`text-primary hover:underline`)
- Link opens in new tab to external X/Twitter post
- No functional changes to component behavior

<h3>Confidence Score: 4/5</h3>


- This PR is safe to merge with minimal risk - it's a simple copy change with proper link security attributes
- The change is straightforward and low-risk: adding a text snippet with a hyperlink. The link includes proper security attributes (target="_blank" with rel="noopener noreferrer") and uses existing design system classes. The only minor consideration is the informal tone ("wilson") which may not fit all brand guidelines, but this appears intentional based on the PR description
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| components/landing/solution.tsx | 4/5 | Added hyperlinked text "Also called outbound email sending, wilson" with external link to a tweet; simple copy change with proper link attributes |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Browser
    participant LandingPage as Landing Page Component
    participant TwitterLink as External Link (X/Twitter)

    User->>Browser: Visit landing page
    Browser->>LandingPage: Render Solution component
    LandingPage->>Browser: Display transactional email section
    Note over LandingPage,Browser: Text includes "Also called outbound<br/>email sending, wilson" with link
    User->>Browser: Click "wilson" hyperlink
    Browser->>TwitterLink: Navigate to tweet (new tab)
    Note over Browser,TwitterLink: Opens https://x.com/itswilsonhou/<br/>status/1981841420534362281
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->