### PR TITLE
fix: disable Better Auth API key rate limits

### DIFF
--- a/lib/auth/auth.ts
+++ b/lib/auth/auth.ts
@@ -232,10 +232,10 @@ export const auth = betterAuth({
 							: undefined,
 		}),
 		apiKey({
+			// Rate limiting disabled - handled by Upstash in E2 middleware (app/api/e2/lib/auth.ts)
+			// This avoids duplicate rate limiting and ensures proper 429 responses instead of 401
 			rateLimit: {
-				enabled: true,
-				timeWindow: 1000, // 1 second in milliseconds
-				maxRequests: 4, // 4 requests per second
+				enabled: false,
 			},
 		}),
 		admin(),


### PR DESCRIPTION
## Summary

- Disables Better Auth's per-API-key rate limiting in favor of Upstash Redis rate limiting

## Problem

Users reported intermittent **401 "Authentication required"** errors when making API calls (e.g., deleting email addresses). The actual cause was hitting Better Auth's rate limit (4 req/sec per key), but the error message was misleading.

**Root cause**: Better Auth's `verifyApiKey()` returns `{ valid: false }` when rate-limited, and our E2 middleware treated all invalid responses as auth failures → 401.

## Solution

Disable Better Auth rate limits entirely. Rate limiting is already handled by Upstash Redis in `app/api/e2/lib/auth.ts` which:

| Feature | Better Auth (disabled) | Upstash (active) |
|---------|----------------------|------------------|
| Limit | 4 req/sec per key | 10 req/sec per user |
| Storage | Postgres (DB write per request) | Redis |
| Error response | 401 (wrong) | 429 with proper headers |
| Headers | None | `X-RateLimit-*`, `Retry-After` |

## Changes

- `lib/auth/auth.ts`: Set `rateLimit.enabled: false` in apiKey plugin config

## Testing

- API calls that previously hit the 4/sec limit will now succeed (up to 10/sec)
- Rate limit errors will correctly return 429 with helpful headers

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches API key authentication behavior; disabling built-in throttling relies on external middleware being correctly configured, which could affect protection against abuse if misconfigured.
> 
> **Overview**
> Disables Better Auth’s per-API-key rate limiting by setting `apiKey().rateLimit.enabled` to `false` in `lib/auth/auth.ts`.
> 
> Adds inline comments clarifying that rate limiting is handled elsewhere (Upstash in E2 middleware) to avoid duplicate limits and to return proper `429` responses instead of misleading `401`s.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b9de77e9127bcb3639739a20289104fe3f323d43. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->