### PR TITLE
docs: fix broken links

### DIFF
--- a/docs/api-reference/introduction.mdx
+++ b/docs/api-reference/introduction.mdx
@@ -143,7 +143,7 @@ switch (email) {
 ## API Features
 
 <CardGroup cols={2}>
-  <Card title="Send Emails" icon="paper-plane" href="/api-reference/emails/send-email">
+  <Card title="Send Emails" icon="paper-plane" href="/api-reference/emails/send-an-email">
     Send transactional emails with Resend-compatible API
   </Card>
   
@@ -192,7 +192,7 @@ Ready to start building with Inbound? Here are the essential resources to get yo
     Understand API limits and optimization strategies
   </Card>
   
-  <Card title="Send Your First Email" icon="paper-plane" href="/api-reference/emails/send-email">
+  <Card title="Send Your First Email" icon="paper-plane" href="/api-reference/emails/send-an-email">
     Start sending emails with the API
   </Card>
   


### PR DESCRIPTION
This pull request fixes broken links found in the API Reference's Introduction page.