### PR TITLE
fix: prevent silent attachment loss on email forwarding

### DIFF
--- a/lib/email-management/email-forwarder.ts
+++ b/lib/email-management/email-forwarder.ts
@@ -224,8 +224,7 @@ export class EmailForwarder {
         const attachmentContent = await this.getAttachmentContent(params.originalEmail, attachment.filename)
         
         if (!attachmentContent) {
-          console.warn(`⚠️ EmailForwarder - Could not retrieve content for attachment: ${attachment.filename}`)
-          continue
+          throw new Error(`Failed to retrieve content for attachment: ${attachment.filename}. Aborting forward to prevent silent data loss.`)
         }
 
         messageParts.push(


### PR DESCRIPTION
## Problem

When `getAttachmentContent()` fails to retrieve an attachment (missing raw email data, malformed MIME, parser error), the forwarder logs a warning and calls `continue` — silently skipping the attachment. The email still forwards and gets marked as delivered. The success log even reports the original attachment count, not the actual number included.

This means a user can receive a forwarded email that is missing attachments with no indication that anything went wrong. Silent data loss.

## Fix

Replace the `continue` with a `throw` so the forwarding operation fails visibly when an attachment cannot be retrieved. The existing error handling in the caller (`email-router.ts`) already catches this, marks the email as failed, and logs the error — so the failure surfaces properly instead of being swallowed.

## Before

```typescript
if (!attachmentContent) {
  console.warn(`Could not retrieve content for attachment`)
  continue  // email sends without the attachment, marked as delivered
}
```

## After

```typescript
if (!attachmentContent) {
  throw new Error(`Failed to retrieve content for attachment. Aborting forward to prevent silent data loss.`)
}
```

One line change. No new dependencies.

---

[@neilhtennek](https://x.com/neilhtennek) | [@PreviewOps](https://x.com/PreviewOps)