### PR TITLE
update the auth level

### DIFF
--- a/lib/auth/auth.ts
+++ b/lib/auth/auth.ts
@@ -155,11 +155,9 @@ export const auth = betterAuth({
 			currentURL:
 				process.env.NODE_ENV === "development"
 					? (process.env.NEXT_PUBLIC_APP_URL as string)
-					: process.env.VERCEL_URL
-						? `https://${process.env.VERCEL_URL}`
-						: process.env.VERCEL_BRANCH_URL
-							? `https://${process.env.VERCEL_BRANCH_URL}`
-							: undefined,
+					: process.env.VERCEL_ENV === "preview"
+						? `https://${process.env.VERCEL_BRANCH_URL}`
+						: undefined,
 		}),
 		apiKey({
 			rateLimit: {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches authentication redirect/proxy configuration; a mis-set `currentURL` could break OAuth callbacks specifically on Vercel preview deployments.
> 
> **Overview**
> Updates `oAuthProxy` configuration in `lib/auth/auth.ts` so `currentURL` is only set for development and for Vercel *preview* deployments (using `VERCEL_BRANCH_URL`), removing the previous fallback chain that used `VERCEL_URL`/`VERCEL_BRANCH_URL` in other environments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d89bb5389637a6425c1f221797ff4080a6669aff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->