### PR TITLE
fix: add inbound webhook signature headers

### DIFF
--- a/app/api/e2/[[...slugs]]/route.ts
+++ b/app/api/e2/[[...slugs]]/route.ts
@@ -131,6 +131,8 @@ Every webhook request includes security headers:
 
 | Header | Description |
 |--------|-------------|
+| \`X-Inbound-Signature\` | HMAC-SHA256 signature of the webhook payload |
+| \`X-Webhook-Signature\` | Backward-compatible alias for \`X-Inbound-Signature\` |
 | \`X-Webhook-Verification-Token\` | Unique verification token for your endpoint |
 | \`X-Endpoint-ID\` | ID of the endpoint that triggered this webhook |
 | \`X-Webhook-Event\` | Event type (e.g., \`email.received\`) |

--- a/app/api/e2/endpoints/test.ts
+++ b/app/api/e2/endpoints/test.ts
@@ -10,7 +10,10 @@ import type {
 	InboundEmailHeaders,
 	InboundWebhookPayload,
 } from "@/lib/types/inbound-webhooks";
-import { getOrCreateVerificationToken } from "@/lib/webhooks/verification";
+import {
+	createWebhookSignature,
+	getOrCreateVerificationToken,
+} from "@/lib/webhooks/verification";
 import { generateTestPayload } from "@/lib/webhooks/webhook-formats";
 import { validateAndRateLimit } from "../lib/auth";
 
@@ -360,10 +363,15 @@ export const testEndpoint = new Elysia().post(
 							name: endpoint.name,
 							type: endpoint.type as any,
 						});
+						const testPayloadString = JSON.stringify(testPayload);
 
 						// Get or create verification token for this endpoint
 						const hadToken = !!config.verificationToken;
 						const verificationToken = getOrCreateVerificationToken(config);
+						const signature = createWebhookSignature(
+							testPayloadString,
+							verificationToken,
+						);
 
 						// Save token if it was newly generated
 						if (!hadToken) {
@@ -385,6 +393,8 @@ export const testEndpoint = new Elysia().post(
 							"X-Email-ID": testPayload.email.id,
 							"X-Message-ID": testPayload.email.messageId || "",
 							"X-Webhook-Verification-Token": verificationToken,
+							"X-Webhook-Signature": signature,
+							"X-Inbound-Signature": signature,
 							...customHeaders,
 						};
 
@@ -400,7 +410,7 @@ export const testEndpoint = new Elysia().post(
 						const response = await fetch(effectiveUrl, {
 							method: "POST",
 							headers: requestHeaders,
-							body: JSON.stringify(testPayload),
+							body: testPayloadString,
 							redirect: "error",
 							referrerPolicy: "no-referrer",
 							signal: AbortSignal.timeout(timeoutMs),
@@ -442,10 +452,15 @@ export const testEndpoint = new Elysia().post(
 								recipient: "test@yourdomain.com",
 							},
 						);
+						const testPayloadString = JSON.stringify(testPayload);
 
 						// Get or create verification token for this endpoint
 						const hadToken2 = !!config.verificationToken;
 						const verificationToken2 = getOrCreateVerificationToken(config);
+						const signature = createWebhookSignature(
+							testPayloadString,
+							verificationToken2,
+						);
 
 						// Save token if it was newly generated
 						if (!hadToken2) {
@@ -465,6 +480,8 @@ export const testEndpoint = new Elysia().post(
 							"X-Endpoint-ID": endpoint.id,
 							"X-Webhook-Format": preferredFormat,
 							"X-Webhook-Verification-Token": verificationToken2,
+							"X-Webhook-Signature": signature,
+							"X-Inbound-Signature": signature,
 							...customHeaders,
 						};
 
@@ -480,7 +497,7 @@ export const testEndpoint = new Elysia().post(
 						const response = await fetch(effectiveUrl, {
 							method: "POST",
 							headers: requestHeaders,
-							body: JSON.stringify(testPayload),
+							body: testPayloadString,
 							redirect: "error",
 							referrerPolicy: "no-referrer",
 							signal: AbortSignal.timeout(timeoutMs2),

--- a/lib/email-management/email-router.ts
+++ b/lib/email-management/email-router.ts
@@ -18,7 +18,10 @@ import {
 	endpoints,
 	structuredEmails,
 } from "@/lib/db/schema";
-import { getOrCreateVerificationToken } from "@/lib/webhooks/verification";
+import {
+	createWebhookSignature,
+	getOrCreateVerificationToken,
+} from "@/lib/webhooks/verification";
 import { evaluateGuardRules } from "../guard/rule-matcher";
 import { checkRecipientsAgainstBlocklist } from "./email-blocking";
 import { EmailForwarder } from "./email-forwarder";
@@ -991,6 +994,10 @@ async function handleWebhookEndpoint(
 				);
 			}
 		}
+
+		const signature = createWebhookSignature(finalPayloadString, verificationToken);
+		headers["X-Webhook-Signature"] = signature;
+		headers["X-Inbound-Signature"] = signature;
 
 		// Send the webhook
 		const startTime = Date.now();

--- a/lib/email-management/webhook-trigger.ts
+++ b/lib/email-management/webhook-trigger.ts
@@ -4,7 +4,7 @@
  * and provide a clean interface for triggering email actions.
  */
 
-import { createHash, createHmac } from "crypto";
+import { createHash } from "crypto";
 import { and, eq, sql } from "drizzle-orm";
 import { db } from "@/lib/db";
 import {
@@ -13,7 +13,10 @@ import {
 	webhookDeliveries,
 	webhooks,
 } from "@/lib/db/schema";
-import { generateNewWebhookVerificationToken } from "@/lib/webhooks/verification";
+import {
+	createWebhookSignature,
+	generateNewWebhookVerificationToken,
+} from "@/lib/webhooks/verification";
 import { type ParsedEmailData, sanitizeHtml } from "./email-parser";
 
 function buildLegacyWebhookDeliveryId(
@@ -320,9 +323,7 @@ export async function triggerEmailAction(
 		// Create webhook signature if secret exists
 		let signature = null;
 		if (webhook.secret) {
-			const hmac = createHmac("sha256", webhook.secret);
-			hmac.update(payloadString);
-			signature = `sha256=${hmac.digest("hex")}`;
+			signature = createWebhookSignature(payloadString, webhook.secret);
 		}
 
 		// For legacy webhooks, generate a token (not persisted - endpoints have proper storage)
@@ -355,6 +356,7 @@ export async function triggerEmailAction(
 
 		if (signature) {
 			headers["X-Webhook-Signature"] = signature;
+			headers["X-Inbound-Signature"] = signature;
 		}
 
 		// Add custom headers if any

--- a/lib/webhooks/verification.ts
+++ b/lib/webhooks/verification.ts
@@ -5,7 +5,7 @@
  * Tokens are stored in the endpoint config so end users can access them via the API.
  */
 
-import { randomBytes } from 'crypto'
+import { createHmac, randomBytes } from 'crypto'
 
 /**
  * Generate a new random verification token
@@ -15,6 +15,17 @@ import { randomBytes } from 'crypto'
  */
 export function generateNewWebhookVerificationToken(): string {
   return randomBytes(32).toString('hex')
+}
+
+/**
+ * Create an HMAC signature for a webhook payload.
+ *
+ * @param payload - The exact JSON payload string sent in the request body
+ * @param secret - The webhook verification secret/token
+ * @returns Signature header value in the form sha256=<hex digest>
+ */
+export function createWebhookSignature(payload: string, secret: string): string {
+  return `sha256=${createHmac('sha256', secret).update(payload).digest('hex')}`
 }
 
 /**
@@ -51,4 +62,3 @@ export function verifyWebhookToken(config: any, token: string): boolean {
   
   return config.verificationToken === token
 }
-


### PR DESCRIPTION
Closes #130.

## Summary
- add a shared HMAC helper for webhook payload signatures
- include `X-Inbound-Signature` and the backward-compatible `X-Webhook-Signature` on inbound webhook deliveries
- include the same signature headers for webhook test sends and document them in the API reference

## Testing
- git diff --check
- Not run: Bun-based test suite, because Bun is not installed in my environment