### PR TITLE
fix: restore outbound CID attachment support

### DIFF
--- a/app/api/e2/emails/reply.ts
+++ b/app/api/e2/emails/reply.ts
@@ -579,10 +579,11 @@ export const replyToEmail = new Elysia().post(
 		try {
 			console.log("📤 Sending reply email via AWS SES");
 
-			const customHeaders = body.headers
+			const customHeaders: Record<string, string> | undefined = body.headers
 				? Object.fromEntries(
 						Object.entries(body.headers).filter(
-							([key]) =>
+							(entry): entry is [string, string] =>
+								typeof entry[1] === "string" &&
 								![
 									"from",
 									"to",
@@ -590,7 +591,7 @@ export const replyToEmail = new Elysia().post(
 									"message-id",
 									"in-reply-to",
 									"references",
-								].includes(key.toLowerCase()),
+								].includes(entry[0].toLowerCase()),
 						),
 					)
 				: undefined;

--- a/app/api/e2/emails/reply.ts
+++ b/app/api/e2/emails/reply.ts
@@ -29,8 +29,10 @@ import { checkSendingSpike } from "@/lib/email-management/sending-spike-detector
 import {
 	attachmentsToStorageFormat,
 	processAttachments,
-} from "../helper/attachment-processor";
-import { validateAndRateLimit } from "../lib/auth";
+	type ProcessedAttachment,
+} from "@/app/api/e2/helper/attachment-processor";
+import { buildRawEmailMessage } from "@/app/api/e2/helper/email-builder";
+import { validateAndRateLimit } from "@/app/api/e2/lib/auth";
 
 // Initialize SES client
 const awsRegion = process.env.AWS_REGION || "us-east-2";
@@ -52,9 +54,15 @@ if (awsAccessKeyId && awsSecretAccessKey) {
 // Request schema
 const AttachmentSchema = t.Object({
 	filename: t.String(),
-	content: t.String(),
-	content_type: t.Optional(t.String()),
+	content: t.String({ description: "Base64 encoded attachment content" }),
 	path: t.Optional(t.String()),
+	contentType: t.Optional(t.String({ description: "MIME type of the attachment" })),
+	content_type: t.Optional(t.String()),
+	content_id: t.Optional(
+		t.String({
+			description: "Content-ID used by inline HTML references such as cid:logo",
+		}),
+	),
 });
 
 const TagSchema = t.Object({
@@ -121,43 +129,29 @@ function formatSenderAddress(email: string, name?: string): string {
 	}
 }
 
-function formatEmailDate(date: Date): string {
-	const days = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
-	const months = [
-		"Jan",
-		"Feb",
-		"Mar",
-		"Apr",
-		"May",
-		"Jun",
-		"Jul",
-		"Aug",
-		"Sep",
-		"Oct",
-		"Nov",
-		"Dec",
-	];
-
-	const day = days[date.getUTCDay()];
-	const dayNum = date.getUTCDate();
-	const month = months[date.getUTCMonth()];
-	const year = date.getUTCFullYear();
-	const hours = date.getUTCHours().toString().padStart(2, "0");
-	const minutes = date.getUTCMinutes().toString().padStart(2, "0");
-	const seconds = date.getUTCSeconds().toString().padStart(2, "0");
-
-	return `${day}, ${dayNum} ${month} ${year} ${hours}:${minutes}:${seconds} +0000`;
-}
-
 function extractEmailsFromParsedData(parsedData: string | null): string[] {
 	if (!parsedData) return [];
 
 	try {
-		const parsed = JSON.parse(parsedData);
-		if (parsed?.addresses && Array.isArray(parsed.addresses)) {
+		const parsed: unknown = JSON.parse(parsedData);
+		if (
+			typeof parsed === "object" &&
+			parsed !== null &&
+			"addresses" in parsed &&
+			Array.isArray(parsed.addresses)
+		) {
 			return parsed.addresses
-				.map((addr: any) => addr.address)
-				.filter((email: string) => email && typeof email === "string");
+				.map((address) =>
+					typeof address === "object" &&
+					address !== null &&
+					"address" in address
+						? address.address
+						: undefined,
+				)
+				.filter(
+					(email): email is string =>
+						typeof email === "string" && email.length > 0,
+				);
 		}
 	} catch (e) {
 		console.error("Failed to parse email data:", e);
@@ -167,7 +161,7 @@ function extractEmailsFromParsedData(parsedData: string | null): string[] {
 }
 
 // Check warmup limits for new accounts
-async function checkNewAccountWarmupLimits(userId: string): Promise<{
+async function checkNewAccountWarmupLimits(_userId: string): Promise<{
 	allowed: boolean;
 	error?: string;
 }> {
@@ -438,7 +432,7 @@ export const replyToEmail = new Elysia().post(
 
 		// Process attachments
 		console.log("📎 Processing reply attachments");
-		let processedAttachments: any[] = [];
+		let processedAttachments: ProcessedAttachment[] = [];
 		if (body.attachments && body.attachments.length > 0) {
 			try {
 				processedAttachments = await processAttachments(body.attachments);
@@ -585,108 +579,35 @@ export const replyToEmail = new Elysia().post(
 		try {
 			console.log("📤 Sending reply email via AWS SES");
 
-			// Build raw email message
-			const boundary = `----=_Part_${Date.now()}_${Math.random().toString(36).substring(2)}`;
-			let rawMessage = "";
+			const customHeaders = body.headers
+				? Object.fromEntries(
+						Object.entries(body.headers).filter(
+							([key]) =>
+								![
+									"from",
+									"to",
+									"subject",
+									"message-id",
+									"in-reply-to",
+									"references",
+								].includes(key.toLowerCase()),
+						),
+					)
+				: undefined;
 
-			const formattedMessageId = formatMessageId(messageId);
-
-			rawMessage += `From: ${formattedFromAddress}\r\n`;
-			rawMessage += `To: ${toAddresses.join(", ")}\r\n`;
-			rawMessage += `Subject: ${subject}\r\n`;
-			rawMessage += `Message-ID: ${formattedMessageId}\r\n`;
-
-			if (inReplyTo) {
-				rawMessage += `In-Reply-To: ${inReplyTo}\r\n`;
-			}
-			if (referencesString) {
-				rawMessage += `References: ${referencesString}\r\n`;
-			}
-
-			if (body.headers) {
-				for (const [key, value] of Object.entries(body.headers)) {
-					if (
-						![
-							"from",
-							"to",
-							"subject",
-							"message-id",
-							"in-reply-to",
-							"references",
-						].includes(key.toLowerCase())
-					) {
-						rawMessage += `${key}: ${value}\r\n`;
-					}
-				}
-			}
-
-			rawMessage += `Date: ${formatEmailDate(new Date())}\r\n`;
-			rawMessage += `MIME-Version: 1.0\r\n`;
-
-			// Handle content and attachments
-			if (processedAttachments.length > 0) {
-				rawMessage += `Content-Type: multipart/mixed; boundary="${boundary}"\r\n\r\n`;
-				rawMessage += `--${boundary}\r\n`;
-
-				if (body.html && body.text) {
-					const altBoundary = `----=_Alt_${Date.now()}_${Math.random().toString(36).substring(2)}`;
-					rawMessage += `Content-Type: multipart/alternative; boundary="${altBoundary}"\r\n\r\n`;
-
-					rawMessage += `--${altBoundary}\r\n`;
-					rawMessage += `Content-Type: text/plain; charset=UTF-8\r\n`;
-					rawMessage += `Content-Transfer-Encoding: quoted-printable\r\n\r\n`;
-					rawMessage += `${body.text}\r\n`;
-
-					rawMessage += `--${altBoundary}\r\n`;
-					rawMessage += `Content-Type: text/html; charset=UTF-8\r\n`;
-					rawMessage += `Content-Transfer-Encoding: quoted-printable\r\n\r\n`;
-					rawMessage += `${body.html}\r\n`;
-
-					rawMessage += `--${altBoundary}--\r\n`;
-				} else if (body.html) {
-					rawMessage += `Content-Type: text/html; charset=UTF-8\r\n`;
-					rawMessage += `Content-Transfer-Encoding: quoted-printable\r\n\r\n`;
-					rawMessage += `${body.html}\r\n`;
-				} else {
-					rawMessage += `Content-Type: text/plain; charset=UTF-8\r\n`;
-					rawMessage += `Content-Transfer-Encoding: quoted-printable\r\n\r\n`;
-					rawMessage += `${body.text}\r\n`;
-				}
-
-				for (const attachment of processedAttachments) {
-					rawMessage += `--${boundary}\r\n`;
-					rawMessage += `Content-Type: ${attachment.contentType}\r\n`;
-					rawMessage += `Content-Transfer-Encoding: base64\r\n`;
-					rawMessage += `Content-Disposition: attachment; filename="${attachment.filename}"\r\n\r\n`;
-					rawMessage += `${attachment.content}\r\n`;
-				}
-
-				rawMessage += `--${boundary}--\r\n`;
-			} else {
-				if (body.html && body.text) {
-					rawMessage += `Content-Type: multipart/alternative; boundary="${boundary}"\r\n\r\n`;
-
-					rawMessage += `--${boundary}\r\n`;
-					rawMessage += `Content-Type: text/plain; charset=UTF-8\r\n`;
-					rawMessage += `Content-Transfer-Encoding: quoted-printable\r\n\r\n`;
-					rawMessage += `${body.text}\r\n`;
-
-					rawMessage += `--${boundary}\r\n`;
-					rawMessage += `Content-Type: text/html; charset=UTF-8\r\n`;
-					rawMessage += `Content-Transfer-Encoding: quoted-printable\r\n\r\n`;
-					rawMessage += `${body.html}\r\n`;
-
-					rawMessage += `--${boundary}--\r\n`;
-				} else if (body.html) {
-					rawMessage += `Content-Type: text/html; charset=UTF-8\r\n`;
-					rawMessage += `Content-Transfer-Encoding: quoted-printable\r\n\r\n`;
-					rawMessage += `${body.html}\r\n`;
-				} else {
-					rawMessage += `Content-Type: text/plain; charset=UTF-8\r\n`;
-					rawMessage += `Content-Transfer-Encoding: quoted-printable\r\n\r\n`;
-					rawMessage += `${body.text}\r\n`;
-				}
-			}
+			const rawMessage = buildRawEmailMessage({
+				from: formattedFromAddress,
+				to: toAddresses,
+				subject,
+				textBody: body.text,
+				htmlBody: body.html,
+				messageId,
+				inReplyTo: inReplyTo || undefined,
+				references,
+				customHeaders,
+				attachments: processedAttachments,
+				date: new Date(),
+			});
 
 			// Get tenant sending info
 			const parentDomain = isSubdomain(fromDomain)

--- a/app/api/e2/emails/send.ts
+++ b/app/api/e2/emails/send.ts
@@ -30,14 +30,16 @@ import { checkSendingSpike } from "@/lib/email-management/sending-spike-detector
 import {
 	formatScheduledDate,
 	parseScheduledAt,
+	type ParsedScheduleDate,
 	validateScheduledDate,
 } from "@/lib/utils/date-parser";
 import {
 	attachmentsToStorageFormat,
 	processAttachments,
-} from "../helper/attachment-processor";
-import { buildRawEmailMessage } from "../helper/email-builder";
-import { validateAndRateLimit } from "../lib/auth";
+	type ProcessedAttachment,
+} from "@/app/api/e2/helper/attachment-processor";
+import { buildRawEmailMessage } from "@/app/api/e2/helper/email-builder";
+import { validateAndRateLimit } from "@/app/api/e2/lib/auth";
 
 // Initialize SES client
 const awsRegion = process.env.AWS_REGION || "us-east-2";
@@ -59,9 +61,15 @@ if (awsAccessKeyId && awsSecretAccessKey) {
 // Request schema
 const AttachmentSchema = t.Object({
 	filename: t.String(),
-	content: t.String(),
-	content_type: t.Optional(t.String()),
+	content: t.String({ description: "Base64 encoded attachment content" }),
 	path: t.Optional(t.String()),
+	contentType: t.Optional(t.String({ description: "MIME type of the attachment" })),
+	content_type: t.Optional(t.String()),
+	content_id: t.Optional(
+		t.String({
+			description: "Content-ID used by inline HTML references such as cid:logo",
+		}),
+	),
 });
 
 const TagSchema = t.Object({
@@ -145,7 +153,7 @@ function formatEmailWithName(email: string, name?: string): string {
 }
 
 // Check warmup limits for new accounts
-async function checkNewAccountWarmupLimits(userId: string): Promise<{
+async function checkNewAccountWarmupLimits(_userId: string): Promise<{
 	allowed: boolean;
 	error?: string;
 	emailsSentToday?: number;
@@ -218,7 +226,7 @@ export const sendEmail = new Elysia().post(
 		}
 
 		// Handle scheduled_at if provided
-		let parsedDate: any = null;
+		let parsedDate: ParsedScheduleDate | null = null;
 		if (body.scheduled_at) {
 			console.log("⏰ Scheduled email detected");
 
@@ -226,7 +234,7 @@ export const sendEmail = new Elysia().post(
 			if (!parsedDate.isValid) {
 				console.log("❌ Invalid scheduled_at:", parsedDate.error);
 				set.status = 400;
-				return { error: parsedDate.error };
+				return { error: parsedDate.error || "Invalid scheduled_at value" };
 			}
 
 			const dateValidation = validateScheduledDate(parsedDate.date);
@@ -313,7 +321,7 @@ export const sendEmail = new Elysia().post(
 
 		// Process attachments
 		console.log("📎 Processing attachments");
-		let processedAttachments: any[] = [];
+		let processedAttachments: ProcessedAttachment[] = [];
 		if (body.attachments && body.attachments.length > 0) {
 			try {
 				processedAttachments = await processAttachments(body.attachments);

--- a/app/api/e2/emails/send.ts
+++ b/app/api/e2/emails/send.ts
@@ -241,7 +241,7 @@ export const sendEmail = new Elysia().post(
 			if (!dateValidation.isValid) {
 				console.log("❌ Invalid schedule time:", dateValidation.error);
 				set.status = 400;
-				return { error: dateValidation.error };
+				return { error: dateValidation.error || "Invalid scheduled_at value" };
 			}
 
 			console.log(

--- a/app/api/e2/helper/attachment-processor.ts
+++ b/app/api/e2/helper/attachment-processor.ts
@@ -4,6 +4,98 @@
  * Maintains backward compatibility with existing attachment format
  */
 
+import { lookup } from 'node:dns/promises'
+import { isIP } from 'node:net'
+
+/**
+ * Returns true if an IP address is in a private, loopback, link-local, or
+ * otherwise non-public range that should never be reachable via a
+ * user-supplied attachment URL (SSRF protection - blocks cloud metadata
+ * endpoints like 169.254.169.254, internal services, and loopback).
+ */
+function isBlockedIp(ip: string): boolean {
+  const family = isIP(ip)
+
+  if (family === 4) {
+    const parts = ip.split('.').map(Number)
+    if (parts.length !== 4 || parts.some(p => Number.isNaN(p) || p < 0 || p > 255)) {
+      return true
+    }
+    const [a, b] = parts
+    if (a === 0) return true // 0.0.0.0/8 "this network"
+    if (a === 10) return true // 10.0.0.0/8 private
+    if (a === 127) return true // 127.0.0.0/8 loopback
+    if (a === 169 && b === 254) return true // 169.254.0.0/16 link-local (incl. cloud metadata)
+    if (a === 172 && b >= 16 && b <= 31) return true // 172.16.0.0/12 private
+    if (a === 192 && b === 168) return true // 192.168.0.0/16 private
+    if (a === 100 && b >= 64 && b <= 127) return true // 100.64.0.0/10 CGNAT
+    if (a >= 224) return true // 224.0.0.0/4 multicast + 240.0.0.0/4 reserved
+    return false
+  }
+
+  if (family === 6) {
+    const lower = ip.toLowerCase().replace(/^\[|\]$/g, '')
+    if (lower === '::' || lower === '::1') return true // unspecified / loopback
+    const firstHextet = parseInt(lower.split(':')[0], 16)
+    if (firstHextet >= 0xfe80 && firstHextet <= 0xfebf) return true // link-local fe80::/10
+    if (lower.startsWith('fc') || lower.startsWith('fd')) return true // unique local (fc00::/7)
+    if (lower.startsWith('ff')) return true // multicast
+    // IPv4-mapped / IPv4-compatible - re-check the embedded IPv4. The address may
+    // appear in dotted form (::ffff:127.0.0.1) OR hex form (::ffff:7f00:1) - note
+    // that the WHATWG URL parser normalizes the dotted form to hex, so both must
+    // be handled or loopback/private mapped literals slip through.
+    const dotted = lower.match(/(?:::ffff:|::)(\d+\.\d+\.\d+\.\d+)$/)
+    if (dotted) return isBlockedIp(dotted[1])
+    const hex = lower.match(/(?:::ffff:|::)([0-9a-f]{1,4}):([0-9a-f]{1,4})$/)
+    if (hex) {
+      const high = parseInt(hex[1], 16)
+      const low = parseInt(hex[2], 16)
+      return isBlockedIp(
+        `${(high >> 8) & 0xff}.${high & 0xff}.${(low >> 8) & 0xff}.${low & 0xff}`,
+      )
+    }
+    return false
+  }
+
+  // Not a recognizable IP literal - block to be safe
+  return true
+}
+
+/**
+ * Validate a user-supplied attachment URL against SSRF. Enforces http/https and
+ * resolves the hostname, throwing if it (or any resolved A/AAAA address) is
+ * private/loopback/link-local/metadata. Note: this does not pin the resolved IP
+ * for the subsequent fetch, so a DNS-rebinding attacker could still race the
+ * resolution - redirects are disabled by the caller to narrow that window.
+ */
+async function assertUrlIsSafe(parsedUrl: URL): Promise<void> {
+  if (!['http:', 'https:'].includes(parsedUrl.protocol)) {
+    throw new Error('Only HTTP and HTTPS URLs are supported')
+  }
+
+  const hostname = parsedUrl.hostname.replace(/^\[|\]$/g, '')
+
+  // If the host is an IP literal, validate it directly.
+  if (isIP(hostname)) {
+    if (isBlockedIp(hostname)) {
+      throw new Error('URL host resolves to a non-public address and is not allowed')
+    }
+    return
+  }
+
+  // Otherwise resolve all A/AAAA records and ensure none are private.
+  let resolved: { address: string }[]
+  try {
+    resolved = await lookup(hostname, { all: true })
+  } catch {
+    throw new Error('Unable to resolve attachment URL host')
+  }
+
+  if (resolved.length === 0 || resolved.some(r => isBlockedIp(r.address))) {
+    throw new Error('URL host resolves to a non-public address and is not allowed')
+  }
+}
+
 export interface AttachmentInput {
   // Resend-compatible: either path OR content
   path?: string        // Remote file URL
@@ -134,18 +226,20 @@ async function fetchRemoteFile(url: string): Promise<{ content: string; contentT
   console.log('📥 Fetching remote file:', url)
   
   try {
-    // Validate URL format
+    // Validate URL format + SSRF protection (blocks private/loopback/link-local
+    // and cloud-metadata addresses, e.g. 169.254.169.254).
     const parsedUrl = new URL(url)
-    if (!['http:', 'https:'].includes(parsedUrl.protocol)) {
-      throw new Error('Only HTTP and HTTPS URLs are supported')
-    }
-    
+    await assertUrlIsSafe(parsedUrl)
+
     // Fetch with timeout and size limits
     const controller = new AbortController()
     const timeoutId = setTimeout(() => controller.abort(), 30000) // 30 second timeout
-    
+
     const response = await fetch(url, {
       signal: controller.signal,
+      // Do not follow redirects: a redirect to an internal address would bypass
+      // the SSRF check performed above against the original URL.
+      redirect: 'error',
       headers: {
         'User-Agent': 'InboundEmail-AttachmentFetcher/1.0'
       }
@@ -208,12 +302,20 @@ function processBase64Content(content: string, declaredContentType?: string): { 
   try {
     // Remove data URL prefix if present (e.g., "data:image/png;base64,")
     const base64Content = content.replace(/^data:[^;]+;base64,/, '')
-    
+
+    // Reject oversized payloads BEFORE decoding to avoid allocating a huge
+    // buffer for content that will fail the size check anyway. Base64 expands
+    // by ~4/3, so a string longer than MAX*4/3 (+ padding slack) cannot decode
+    // to a permitted size.
+    if (base64Content.length > Math.ceil(MAX_ATTACHMENT_SIZE * 1.4)) {
+      throw new Error(`File too large (max: ${MAX_ATTACHMENT_SIZE} bytes)`)
+    }
+
     // Validate base64 format
     if (!/^[A-Za-z0-9+/]*={0,2}$/.test(base64Content)) {
       throw new Error('Invalid base64 format')
     }
-    
+
     // Calculate size
     const buffer = Buffer.from(base64Content, 'base64')
     const size = buffer.byteLength
@@ -290,7 +392,7 @@ function detectContentTypeFromBase64(base64: string): string | null {
     }
     
     return null
-  } catch (error) {
+  } catch {
     return null
   }
 }
@@ -351,6 +453,12 @@ function validateContentIds(attachments: AttachmentInput[]): void {
     const attachment = attachments[i]
     
     if (attachment.content_id) {
+      // Reject control characters and angle brackets that would allow MIME
+      // header injection when the content_id is emitted as Content-ID: <...>
+      if (/[\r\n\t<>"]/.test(attachment.content_id)) {
+        throw new Error(`Attachment ${i + 1}: content_id contains invalid characters`)
+      }
+
       // Check length limit (Resend spec: max 128 characters)
       if (attachment.content_id.length > 128) {
         throw new Error(`Attachment ${i + 1}: content_id must be less than 128 characters (current: ${attachment.content_id.length})`)
@@ -475,11 +583,13 @@ export function attachmentsToStorageFormat(attachments: ProcessedAttachment[]): 
   filename: string
   content_type: string
   size?: number
+  content_id?: string
 }> {
   return attachments.map(att => ({
     content: att.content,
     filename: att.filename,
     content_type: att.contentType,
-    size: att.size
+    size: att.size,
+    content_id: att.content_id
   }))
 }

--- a/app/api/e2/helper/attachment-processor.ts
+++ b/app/api/e2/helper/attachment-processor.ts
@@ -453,9 +453,9 @@ function validateContentIds(attachments: AttachmentInput[]): void {
     const attachment = attachments[i]
     
     if (attachment.content_id) {
-      // Reject control characters and angle brackets that would allow MIME
+      // Reject whitespace-only values, control characters, and angle brackets that would allow MIME
       // header injection when the content_id is emitted as Content-ID: <...>
-      if (/[\r\n\t<>"]/.test(attachment.content_id)) {
+      if (!attachment.content_id.trim() || /[\x00-\x1F\x7F<>"]/.test(attachment.content_id)) {
         throw new Error(`Attachment ${i + 1}: content_id contains invalid characters`)
       }
 

--- a/app/api/e2/helper/email-builder.test.ts
+++ b/app/api/e2/helper/email-builder.test.ts
@@ -124,6 +124,30 @@ describe("header injection hardening", () => {
 			]),
 		).rejects.toThrow(/invalid characters/i);
 	});
+
+	it("rejects whitespace-only content_id values", async () => {
+		await expect(
+			processAttachments([
+				{
+					filename: "logo.png",
+					content: "iVBORw0KGgo=",
+					content_id: "   ",
+				},
+			]),
+		).rejects.toThrow(/invalid characters/i);
+	});
+
+	it("rejects non-whitespace C0 controls in content_id", async () => {
+		await expect(
+			processAttachments([
+				{
+					filename: "logo.png",
+					content: "iVBORw0KGgo=",
+					content_id: "logo\u0000suffix",
+				},
+			]),
+		).rejects.toThrow(/invalid characters/i);
+	});
 });
 
 describe("quoted-printable encoding", () => {

--- a/app/api/e2/helper/email-builder.test.ts
+++ b/app/api/e2/helper/email-builder.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from "bun:test";
+import {
+	attachmentsToStorageFormat,
+	processAttachments,
+} from "@/app/api/e2/helper/attachment-processor";
+import { buildRawEmailMessage } from "@/app/api/e2/helper/email-builder";
+
+describe("outbound inline attachments", () => {
+	it("builds a related MIME part with CID headers", async () => {
+		const [attachment] = await processAttachments([
+			{
+				filename: "logo.png",
+				content: "iVBORw0KGgo=",
+				content_type: "image/png",
+				content_id: "logo",
+			},
+		]);
+
+		const message = buildRawEmailMessage({
+			from: "sender@example.com",
+			to: ["recipient@example.com"],
+			subject: "Inline image",
+			htmlBody: '<img src="cid:logo">',
+			attachments: [attachment],
+		});
+
+		expect(message).toContain("Content-Type: multipart/related;");
+		expect(message).toContain("Content-ID: <logo>");
+		expect(message).toContain(
+			'Content-Disposition: inline; filename="logo.png"',
+		);
+	});
+
+	it("preserves CID data when storing processed attachments", async () => {
+		const attachments = await processAttachments([
+			{
+				filename: "logo.png",
+				content: "iVBORw0KGgo=",
+				content_id: "logo",
+			},
+		]);
+
+		expect(attachmentsToStorageFormat(attachments)[0].content_id).toBe("logo");
+	});
+});
+
+describe("header injection hardening", () => {
+	const headerBlock = (msg: string) => msg.split("\r\n\r\n")[0];
+
+	it("neutralizes CRLF injected via the subject", () => {
+		const msg = buildRawEmailMessage({
+			from: "a@example.com",
+			to: ["v@example.com"],
+			subject: "Hi\r\nBcc: attacker@evil.com\r\nX-Injected: 1",
+			textBody: "body",
+		});
+		const lines = headerBlock(msg).split("\r\n");
+		// No injected header line: the payload stays inside the Subject value
+		expect(lines.some((l) => l.startsWith("Bcc:"))).toBe(false);
+		expect(lines.some((l) => l.startsWith("X-Injected:"))).toBe(false);
+		expect(
+			lines.some((l) => l === "Subject: Hi Bcc: attacker@evil.com X-Injected: 1"),
+		).toBe(true);
+	});
+
+	it("neutralizes CRLF injected via custom header values and recipients", () => {
+		const msg = buildRawEmailMessage({
+			from: "a@example.com",
+			to: ["Foo <user@example.com>\r\nBcc: attacker@evil.com"],
+			replyTo: ["r@example.com\r\nX-Inj: 1"],
+			subject: "hi",
+			textBody: "body",
+			customHeaders: { "X-Foo": "bar\r\nEvil: injected" },
+		});
+		const lines = headerBlock(msg).split("\r\n");
+		expect(lines.some((l) => l.startsWith("Bcc:"))).toBe(false);
+		expect(lines.some((l) => l === "Evil: injected")).toBe(false);
+		expect(lines.some((l) => l.startsWith("X-Inj:"))).toBe(false);
+	});
+
+	it("preserves legitimate values containing hyphens and brackets", () => {
+		const msg = buildRawEmailMessage({
+			from: "foo-bar@my-domain.com",
+			to: ["a@b.com"],
+			subject: "Re: order-12345 [shipped]",
+			textBody: "x",
+		});
+		expect(msg).toContain("From: foo-bar@my-domain.com");
+		expect(msg).toContain("Subject: Re: order-12345 [shipped]");
+	});
+
+	it("strips CRLF/quotes from attachment filename and content_id headers", async () => {
+		const [attachment] = await processAttachments([
+			{ filename: "logo.png", content: "iVBORw0KGgo=", content_id: "logo" },
+		]);
+		const malicious = {
+			...attachment,
+			filename: 'logo.png"\r\nX-Evil: injected',
+			content_id: "logo>\r\nX-Evil2: yes",
+		};
+		const msg = buildRawEmailMessage({
+			from: "a@b.com",
+			to: ["v@x.com"],
+			subject: "hi",
+			htmlBody: "<p>x</p>",
+			attachments: [malicious],
+		});
+		// No standalone injected MIME header line; payload stays inside the
+		// (now single-line) Content-ID / Content-Disposition values.
+		const lines = msg.split("\r\n");
+		expect(lines.some((l) => l.startsWith("X-Evil:"))).toBe(false);
+		expect(lines.some((l) => l.startsWith("X-Evil2:"))).toBe(false);
+		expect(lines.some((l) => l.startsWith("Content-ID:"))).toBe(true);
+	});
+
+	it("rejects content_id containing control characters at validation time", async () => {
+		await expect(
+			processAttachments([
+				{
+					filename: "logo.png",
+					content: "iVBORw0KGgo=",
+					content_id: "logo\r\nX-Evil: 1",
+				},
+			]),
+		).rejects.toThrow(/invalid characters/i);
+	});
+});
+
+describe("quoted-printable encoding", () => {
+	it("soft-wraps long lines at 76 characters and encodes 8-bit content", () => {
+		const msg = buildRawEmailMessage({
+			from: "a@b.com",
+			to: ["v@x.com"],
+			subject: "s",
+			textBody: `${"A".repeat(200)} café =test`,
+		});
+		const bodyLines = msg.split("\r\n\r\n").slice(1).join("\r\n\r\n").split("\r\n");
+		expect(Math.max(...bodyLines.map((l) => l.length))).toBeLessThanOrEqual(76);
+		expect(msg).toContain("caf=C3=A9"); // é encoded
+		expect(msg).toContain("=3Dtest"); // '=' encoded
+	});
+});

--- a/app/api/e2/helper/email-builder.ts
+++ b/app/api/e2/helper/email-builder.ts
@@ -33,6 +33,47 @@ function extractDomain(email: string): string {
 }
 
 /**
+ * Strip CR/LF (and other control chars) from a value destined for an email
+ * header. This is the primary defense against email header / MIME injection
+ * (CWE-93): every header field below is assembled by string interpolation and
+ * the parts are joined with CRLF, so an embedded CR/LF in any value would
+ * otherwise start an attacker-controlled header line or terminate the header
+ * block. Folding whitespace is collapsed to a single space so the resulting
+ * value stays a single logical header line.
+ */
+function sanitizeHeaderValue(value: string): string {
+  // Replace CR/LF/tab with a single space, then drop any remaining C0/DEL
+  // control characters. Regular spaces and printable content are preserved.
+  return String(value).replace(/[\r\n\t]+/g, " ").replace(/[\x00-\x1F\x7F]/g, "").trim();
+}
+
+/**
+ * Sanitize a custom header NAME. Header names may not contain CR/LF, spaces,
+ * colons or other separators (RFC 5322 field-name = printable US-ASCII minus
+ * ':'). Anything illegal is dropped.
+ */
+function sanitizeHeaderName(name: string): string {
+  return String(name).replace(/[^A-Za-z0-9!#$%&'*+\-.^_`|~]/g, '')
+}
+
+/**
+ * Sanitize an attachment filename for use inside a quoted parameter value
+ * (filename="..."). Strips CR/LF and removes double quotes so the value cannot
+ * break out of the quoted string and inject additional header lines.
+ */
+function sanitizeFilename(filename: string): string {
+  return String(filename).replace(/[\r\n\t]+/g, ' ').replace(/"/g, '').trim()
+}
+
+/**
+ * Sanitize a Content-ID value placed inside <...>. Strips CR/LF and angle
+ * brackets so it cannot escape the Content-ID header.
+ */
+function sanitizeContentId(contentId: string): string {
+  return String(contentId).replace(/[\r\n\t<>]+/g, '').trim()
+}
+
+/**
  * Format date for email headers (RFC 2822)
  */
 function formatEmailDate(date: Date): string {
@@ -62,12 +103,66 @@ function generateBoundary(): string {
  * Uses quoted-printable for text and base64 for attachments
  */
 function encodeQuotedPrintable(text: string): string {
-  // Simple quoted-printable encoding for basic text
-  // For production, consider using a proper library
-  return text
-    .replace(/=/g, '=3D')
-    .replace(/\r\n/g, '\n')
-    .replace(/\n/g, '\r\n')
+  // RFC 2045 quoted-printable encoding.
+  // Encodes any byte that is not a printable ASCII "safe" character (and the
+  // '=' escape char) as =XX, preserves spaces/tabs except at end-of-line, and
+  // enforces the 76-character soft line-length limit with "=\r\n" soft breaks.
+  // This prevents the prior implementation's RFC 5321 998-octet line-length
+  // violations and mislabelled raw 8-bit (UTF-8) bytes under a declared QP body.
+  const bytes = Buffer.from(text, 'utf-8')
+  const lines: string[] = []
+  let line = ''
+
+  const pushSoftBreak = () => {
+    // RFC 2045: whitespace must not sit at the end of an encoded line. If the
+    // line ends in a space/tab, carry it to the start of the next line (legal
+    // there) instead of emitting "<space>=", which decoders may strip.
+    let carry = ''
+    if (line.endsWith(' ') || line.endsWith('\t')) {
+      carry = line.slice(-1)
+      line = line.slice(0, -1)
+    }
+    lines.push(`${line}=`)
+    line = carry
+  }
+
+  const appendToken = (token: string) => {
+    // Keep room for a trailing soft-break '=' within the 76-char limit
+    if (line.length + token.length > 75) {
+      pushSoftBreak()
+    }
+    line += token
+  }
+
+  for (let i = 0; i < bytes.length; i++) {
+    const byte = bytes[i]
+
+    // Hard line break: normalize CR, LF and CRLF to a single CRLF
+    if (byte === 0x0d || byte === 0x0a) {
+      if (byte === 0x0d && bytes[i + 1] === 0x0a) i++ // consume LF of CRLF pair
+      lines.push(line)
+      line = ''
+      continue
+    }
+
+    const isSpace = byte === 0x20 || byte === 0x09 // space or tab
+    const isPrintable = byte >= 0x21 && byte <= 0x7e && byte !== 0x3d // '!'..'~' except '='
+
+    if (isPrintable) {
+      appendToken(String.fromCharCode(byte))
+    } else if (isSpace) {
+      // A space/tab is literal unless it is the last char before a line break,
+      // in which case it must be encoded. Look ahead to decide.
+      const next = bytes[i + 1]
+      const atEndOfLine = next === undefined || next === 0x0d || next === 0x0a
+      appendToken(atEndOfLine ? `=${byte.toString(16).toUpperCase().padStart(2, '0')}` : String.fromCharCode(byte))
+    } else {
+      appendToken(`=${byte.toString(16).toUpperCase().padStart(2, '0')}`)
+    }
+  }
+
+  lines.push(line)
+  return lines.join('\r\n')
 }
 
 /**
@@ -78,7 +173,6 @@ export function buildRawEmailMessage(params: EmailMessageParams): string {
     from,
     to,
     cc,
-    bcc,
     replyTo,
     subject,
     textBody,
@@ -93,8 +187,7 @@ export function buildRawEmailMessage(params: EmailMessageParams): string {
 
   const hasText = !!textBody
   const hasHtml = !!htmlBody
-  const hasAttachments = attachments.length > 0
-  
+
   // Separate CID attachments from regular attachments
   const cidAttachments = attachments.filter(att => att.content_id)
   const regularAttachments = attachments.filter(att => !att.content_id)
@@ -144,25 +237,31 @@ export function buildRawEmailMessage(params: EmailMessageParams): string {
     })
   }
   
-  // Build headers
+  // Build headers. Every interpolated value is passed through
+  // sanitizeHeaderValue to strip CR/LF/control characters, preventing email
+  // header / MIME injection (CWE-93) - the parts below are joined with CRLF, so
+  // an unsanitized newline in any field would inject attacker-controlled header
+  // lines or terminate the header block.
   const headers = [
-    `From: ${from}`,
-    `To: ${to.join(', ')}`,
-    cc && cc.length > 0 ? `Cc: ${cc.join(', ')}` : null,
-    replyTo && replyTo.length > 0 ? `Reply-To: ${replyTo.join(', ')}` : null,
-    `Subject: ${subject}`,
+    `From: ${sanitizeHeaderValue(from)}`,
+    `To: ${to.map(sanitizeHeaderValue).join(', ')}`,
+    cc && cc.length > 0 ? `Cc: ${cc.map(sanitizeHeaderValue).join(', ')}` : null,
+    replyTo && replyTo.length > 0 ? `Reply-To: ${replyTo.map(sanitizeHeaderValue).join(', ')}` : null,
+    `Subject: ${sanitizeHeaderValue(subject)}`,
     // Only add Message-ID if not provided in custom headers
-    formattedMessageId ? `Message-ID: ${formattedMessageId}` : null,
-    formattedInReplyTo ? `In-Reply-To: ${formattedInReplyTo}` : null,
-    formattedReferences.length > 0 ? `References: ${formattedReferences.join(' ')}` : null,
+    formattedMessageId ? `Message-ID: ${sanitizeHeaderValue(formattedMessageId)}` : null,
+    formattedInReplyTo ? `In-Reply-To: ${sanitizeHeaderValue(formattedInReplyTo)}` : null,
+    formattedReferences.length > 0 ? `References: ${formattedReferences.map(sanitizeHeaderValue).join(' ')}` : null,
     `Date: ${formatEmailDate(date)}`,
     'MIME-Version: 1.0',
   ].filter((header): header is string => header !== null)
-  
-  // Add custom headers
+
+  // Add custom headers (name and value both sanitized; empty/invalid names skipped)
   if (customHeaders) {
     for (const [key, value] of Object.entries(customHeaders)) {
-      headers.push(`${key}: ${value}`)
+      const safeKey = sanitizeHeaderName(key)
+      if (!safeKey) continue
+      headers.push(`${safeKey}: ${sanitizeHeaderValue(value)}`)
     }
   }
   
@@ -242,11 +341,11 @@ function addContentAndCidAttachments(
   // CID attachments
   for (const attachment of cidAttachments) {
     messageParts.push(`--${relatedBoundary}`)
-    messageParts.push(`Content-Type: ${attachment.contentType}`)
+    messageParts.push(`Content-Type: ${sanitizeHeaderValue(attachment.contentType)}`)
     messageParts.push('Content-Transfer-Encoding: base64')
-    messageParts.push(`Content-ID: <${attachment.content_id}>`)
-    messageParts.push(`Content-Disposition: inline; filename="${attachment.filename}"`)
-    console.log(`📎 Added CID attachment: <${attachment.content_id}> for ${attachment.filename}`)
+    messageParts.push(`Content-ID: <${sanitizeContentId(attachment.content_id || '')}>`)
+    messageParts.push(`Content-Disposition: inline; filename="${sanitizeFilename(attachment.filename)}"`)
+    console.log(`📎 Added CID attachment: <${sanitizeContentId(attachment.content_id || '')}> for ${sanitizeFilename(attachment.filename)}`)
     messageParts.push('')
     
     // Split base64 content into 76-character lines (RFC requirement)
@@ -263,9 +362,9 @@ function addContentAndCidAttachments(
  */
 function addRegularAttachment(messageParts: string[], boundary: string, attachment: ProcessedAttachment) {
   messageParts.push(`--${boundary}`)
-  messageParts.push(`Content-Type: ${attachment.contentType}`)
+  messageParts.push(`Content-Type: ${sanitizeHeaderValue(attachment.contentType)}`)
   messageParts.push('Content-Transfer-Encoding: base64')
-  messageParts.push(`Content-Disposition: attachment; filename="${attachment.filename}"`)
+  messageParts.push(`Content-Disposition: attachment; filename="${sanitizeFilename(attachment.filename)}"`)
   messageParts.push('')
   
   // Split base64 content into 76-character lines (RFC requirement)

--- a/app/api/e2/helper/email-builder.ts
+++ b/app/api/e2/helper/email-builder.ts
@@ -70,7 +70,7 @@ function sanitizeFilename(filename: string): string {
  * brackets so it cannot escape the Content-ID header.
  */
 function sanitizeContentId(contentId: string): string {
-  return String(contentId).replace(/[\r\n\t<>]+/g, '').trim()
+  return String(contentId).replace(/[\x00-\x1F\x7F<>]+/g, '').trim()
 }
 
 /**

--- a/app/api/e2/helper/main.ts
+++ b/app/api/e2/helper/main.ts
@@ -94,7 +94,8 @@ export async function validateRequest(request: NextRequest) {
 				if (apiKeyUserId) {
 					userId = apiKeyUserId;
 					console.log("🔑 [V2] Auth Type: API_KEY");
-					console.log("🔑 [V2] API Key:", apiKey);
+					// Never log any portion of the API key.
+					console.log("🔑 [V2] API Key: [redacted]", `(${apiKey.length} chars)`);
 					console.log("✅ Authenticated via API key:", userId);
 				}
 			}

--- a/app/api/e2/lib/auth.ts
+++ b/app/api/e2/lib/auth.ts
@@ -175,7 +175,8 @@ export async function validateAndRateLimit(
 		} else if (apiSession?.valid && !apiSession?.error && apiKeyUserId) {
 			userId = apiKeyUserId;
 			console.log("🔑 [E2] Auth Type: API_KEY");
-			console.log("🔑 [E2] API Key:", apiKey);
+			// Never log any portion of the API key.
+			console.log("🔑 [E2] API Key: [redacted]", `(${apiKey.length} chars)`);
 			console.log("✅ API key authentication successful for userId:", userId);
 		} else {
 			console.log("❌ Authentication failed: No valid session or API key");

--- a/lib/api-types.ts
+++ b/lib/api-types.ts
@@ -556,6 +556,8 @@ export interface AttachmentInput {
 	filename: string;
 	content: string; // Base64 encoded
 	contentType?: string;
+	content_type?: string;
+	content_id?: string;
 }
 
 export interface PostEmailsRequest {


### PR DESCRIPTION
## Summary
- restore outbound `content_id` support for send and reply attachment schemas
- preserve CID metadata for queued sends and route replies through the CID-aware multipart MIME builder
- harden attachment URL fetching, MIME header construction, quoted-printable encoding, and API-key logging

## Verification
- `bun test app/api/e2/helper/email-builder.test.ts`
- `bunx biome lint app/api/e2/emails/send.ts app/api/e2/emails/reply.ts app/api/e2/helper/attachment-processor.ts app/api/e2/helper/email-builder.ts app/api/e2/helper/email-builder.test.ts app/api/e2/helper/main.ts app/api/e2/lib/auth.ts lib/api-types.ts`
- `bun run generate:openapi`
- `git diff --check origin/main...HEAD`

## Notes
- Full-repository `bun run lint` still reports existing diagnostics outside this change set.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect production email send/reply and MIME construction (SSRF, header injection, encoding); mitigations are tested but any MIME regression could break delivery or threading.
> 
> **Overview**
> Restores **inline CID attachments** (`content_id`) on send/reply APIs and keeps CID metadata through processing, storage, and **multipart/related** MIME via the shared `buildRawEmailMessage` path (reply no longer builds raw MIME inline).
> 
> **Security and correctness** on the outbound pipeline: SSRF checks and no redirects for remote attachment URLs, stricter `content_id` validation, pre-decode base64 size limits, **header/MIME injection sanitization** and real **quoted-printable** encoding in `email-builder`, plus **API key values redacted** in logs. Shared imports/types tightened (`ProcessedAttachment`, schedule parsing).
> 
> Adds **`email-builder.test.ts`** covering CID MIME, injection hardening, and QP encoding; updates public **`AttachmentInput`** types.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b94cfeee03706782dfbe46d5084fd016419f4af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->