### PR TITLE
feat: add 'to' recipient criterion to guard rules

### DIFF
--- a/app/(main)/guard/rules/[id]/page.tsx
+++ b/app/(main)/guard/rules/[id]/page.tsx
@@ -135,6 +135,9 @@ export default function GuardRuleDetailPage() {
           (parsed.from === undefined ||
             (typeof parsed.from === "object" &&
               Array.isArray(parsed.from.values))) &&
+          (parsed.to === undefined ||
+            (typeof parsed.to === "object" &&
+              Array.isArray(parsed.to.values))) &&
           (parsed.hasAttachment === undefined ||
             typeof parsed.hasAttachment === "boolean") &&
           (parsed.hasWords === undefined ||

--- a/app/(main)/guard/rules/create/page.tsx
+++ b/app/(main)/guard/rules/create/page.tsx
@@ -60,6 +60,8 @@ export default function CreateGuardRulePage() {
   const [subjectValues, setSubjectValues] = useState<string[]>([""]);
   const [fromOperator, setFromOperator] = useState<LogicOperator>("OR");
   const [fromValues, setFromValues] = useState<string[]>([""]);
+  const [toOperator, setToOperator] = useState<LogicOperator>("OR");
+  const [toValues, setToValues] = useState<string[]>([""]);
   const [hasAttachment, setHasAttachment] = useState<boolean | undefined>(
     undefined
   );
@@ -126,15 +128,16 @@ export default function CreateGuardRulePage() {
       // We need to check explicitly for boolean values, not just truthiness
       const hasSubject = subjectValues.some((v) => v.trim());
       const hasFrom = fromValues.some((v) => v.trim());
+      const hasTo = toValues.some((v) => v.trim());
       const hasAttachmentCriteria = typeof hasAttachment === "boolean";
       const hasWords = wordsValues.some((v) => v.trim());
 
       const hasAnyConfig =
-        hasSubject || hasFrom || hasAttachmentCriteria || hasWords;
+        hasSubject || hasFrom || hasTo || hasAttachmentCriteria || hasWords;
 
       if (!hasAnyConfig) {
         newErrors.config =
-          "At least one criteria must be configured (subject, from, attachment, or words)";
+          "At least one criteria must be configured (subject, from, to, attachment, or words)";
       }
     } else {
       if (!aiPrompt.trim()) {
@@ -182,6 +185,12 @@ export default function CreateGuardRulePage() {
           from: {
             operator: fromOperator,
             values: fromValues.filter((v) => v.trim()),
+          },
+        }),
+        ...(toValues.some((v) => v.trim()) && {
+          to: {
+            operator: toOperator,
+            values: toValues.filter((v) => v.trim()),
           },
         }),
         ...(hasAttachment !== undefined && { hasAttachment }),
@@ -492,6 +501,72 @@ export default function CreateGuardRulePage() {
                     </Button>
                     <p className="text-sm text-muted-foreground">
                       Supports wildcards like *@domain.com
+                    </p>
+                  </div>
+
+                  <Separator />
+
+                  {/* To */}
+                  <div className="space-y-3">
+                    <div className="flex items-center justify-between">
+                      <Label>To (Email Address)</Label>
+                      <Select
+                        value={toOperator}
+                        onValueChange={(v) =>
+                          setToOperator(v as LogicOperator)
+                        }
+                      >
+                        <SelectTrigger className="w-24">
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="OR">OR</SelectItem>
+                          <SelectItem value="AND">AND</SelectItem>
+                        </SelectContent>
+                      </Select>
+                    </div>
+                    {toValues.map((value, index) => (
+                      <div key={index} className="flex items-center gap-2">
+                        <Input
+                          value={value}
+                          onChange={(e) =>
+                            handleValueChange(
+                              index,
+                              e.target.value,
+                              toValues,
+                              setToValues
+                            )
+                          }
+                          placeholder="email@domain.com or *@domain.com"
+                        />
+                        {toValues.length > 1 && (
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={() =>
+                              handleRemoveValue(
+                                index,
+                                toValues,
+                                setToValues
+                              )
+                            }
+                          >
+                            <Trash2 width="16" height="16" />
+                          </Button>
+                        )}
+                      </div>
+                    ))}
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => handleAddValue(toValues, setToValues)}
+                    >
+                      <CirclePlus width="16" height="16" className="mr-2" />
+                      Add Value
+                    </Button>
+                    <p className="text-sm text-muted-foreground">
+                      Matches the recipient address. Supports wildcards like
+                      *@domain.com
                     </p>
                   </div>
 

--- a/app/api/e2/guard/generate.ts
+++ b/app/api/e2/guard/generate.ts
@@ -27,6 +27,12 @@ const ExplicitRuleConfigSchema = t.Object({
 			values: t.Array(t.String()),
 		}),
 	),
+	to: t.Optional(
+		t.Object({
+			operator: t.Union([t.Literal("OR"), t.Literal("AND")]),
+			values: t.Array(t.String()),
+		}),
+	),
 	hasAttachment: t.Optional(t.Boolean()),
 	hasWords: t.Optional(
 		t.Object({
@@ -86,6 +92,14 @@ export const generateGuardRules = new Elysia().post(
 							.describe("Email addresses or patterns like *@domain.com"),
 					})
 					.optional(),
+				to: z
+					.object({
+						operator: z.enum(["OR", "AND"]),
+						values: z
+							.array(z.string())
+							.describe("Recipient email addresses or patterns like *@domain.com"),
+					})
+					.optional(),
 				hasAttachment: z.boolean().optional(),
 				hasWords: z
 					.object({
@@ -100,6 +114,7 @@ export const generateGuardRules = new Elysia().post(
 Available rule criteria:
 - subject: Match email subjects containing specific words/phrases
 - from: Match sender email addresses (supports wildcards like *@domain.com for whole domains)
+- to: Match recipient email addresses (supports wildcards like *@domain.com for whole domains)
 - hasAttachment: Match emails with/without attachments
 - hasWords: Match emails with body containing specific words/phrases
 
@@ -111,6 +126,7 @@ Examples:
 - "Block emails from marketing@spam.com" -> { from: { operator: "OR", values: ["marketing@spam.com"] } }
 - "Filter all emails from example.com domain" -> { from: { operator: "OR", values: ["*@example.com"] } }
 - "Match emails with urgent or important in subject" -> { subject: { operator: "OR", values: ["urgent", "important"] } }
+- "Match emails sent to support@mydomain.com" -> { to: { operator: "OR", values: ["support@mydomain.com"] } }
 - "Match emails with attachments" -> { hasAttachment: true }
 
 Generate a config that best matches the user's intent. Only include relevant criteria.`;

--- a/content/blog/inbound-guard.mdx
+++ b/content/blog/inbound-guard.mdx
@@ -35,6 +35,8 @@ Guard gives you two completely different approaches to filtering, and you can mi
 
 - Sender addresses (supports wildcards like *@sketchy-domain.com)
 
+- Recipient addresses (scope rules to a specific inbox, supports wildcards)
+
 - Body content (specific words or phrases)
 
 - Whether an email has attachments

--- a/features/guard/types/index.ts
+++ b/features/guard/types/index.ts
@@ -33,6 +33,10 @@ export interface ExplicitRuleConfig {
     operator: LogicOperator;
     values: string[]; // Supports wildcards like *@domain.com
   };
+  to?: {
+    operator: LogicOperator;
+    values: string[]; // Supports wildcards like *@domain.com
+  };
   hasAttachment?: boolean;
   hasWords?: {
     operator: LogicOperator;

--- a/lib/guard/rule-matcher.test.ts
+++ b/lib/guard/rule-matcher.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "bun:test";
+import type { ExplicitRuleConfig } from "@/features/guard/types";
+import type { structuredEmails } from "@/lib/db/schema";
+
+type StructuredEmail = typeof structuredEmails.$inferSelect;
+
+process.env.DATABASE_URL ??= "postgresql://user:password@example.com/database";
+
+const { checkExplicitRule } = await import("@/lib/guard/rule-matcher");
+
+function buildStructuredEmail(overrides: Partial<StructuredEmail>): StructuredEmail {
+	return {
+		id: "email_1",
+		emailId: "email_1",
+		sesEventId: "ses_1",
+		messageId: "<message@example.com>",
+		date: null,
+		subject: "Hello",
+		recipient: "inbox-b@example.com",
+		fromData: null,
+		toData: null,
+		ccData: null,
+		bccData: null,
+		replyToData: null,
+		inReplyTo: null,
+		references: null,
+		textBody: null,
+		htmlBody: null,
+		rawContent: null,
+		attachments: null,
+		headers: null,
+		priority: null,
+		parseSuccess: true,
+		parseError: null,
+		isRead: false,
+		readAt: null,
+		isArchived: false,
+		archivedAt: null,
+		guardBlocked: false,
+		guardReason: null,
+		guardRuleId: null,
+		guardAction: null,
+		guardMetadata: null,
+		userId: "user_1",
+		createdAt: null,
+		updatedAt: null,
+		threadId: null,
+		threadPosition: null,
+		...overrides,
+	};
+}
+
+describe("guard explicit To rules", () => {
+	it("matches against the delivered recipient instead of every visible To header address", async () => {
+		const config: ExplicitRuleConfig = {
+			to: {
+				operator: "OR",
+				values: ["inbox-a@example.com"],
+			},
+		};
+		const email = buildStructuredEmail({
+			recipient: "inbox-b@example.com",
+			toData: JSON.stringify({
+				text: "inbox-a@example.com, inbox-b@example.com",
+				addresses: [
+					{ name: null, address: "inbox-a@example.com" },
+					{ name: null, address: "inbox-b@example.com" },
+				],
+			}),
+		});
+
+		await expect(checkExplicitRule(config, email)).resolves.toMatchObject({
+			matched: false,
+		});
+	});
+});

--- a/lib/guard/rule-matcher.ts
+++ b/lib/guard/rule-matcher.ts
@@ -153,7 +153,7 @@ export async function checkExplicitRule(
     }
   }
 
-  // Check to criteria (recipient address + To header addresses)
+  // Check to criteria against the delivered recipient address
   if (config.to) {
     try {
       const toAddresses = getRecipientAddresses(email);

--- a/lib/guard/rule-matcher.ts
+++ b/lib/guard/rule-matcher.ts
@@ -156,6 +156,31 @@ async function checkExplicitRule(
     }
   }
 
+  // Check to criteria (recipient address + To header addresses)
+  if (config.to) {
+    try {
+      const toAddresses = getRecipientAddresses(email);
+
+      const toMatches = checkEmailCriteria(
+        toAddresses,
+        config.to.values,
+        config.to.operator
+      );
+
+      if (toMatches) {
+        matchDetails.push({
+          criteria: 'to',
+          value: `Matched with ${config.to.operator} logic`,
+        });
+      } else {
+        allCriteriaMatch = false;
+      }
+    } catch (error) {
+      console.error('Failed to parse toData:', error);
+      allCriteriaMatch = false;
+    }
+  }
+
   // Check attachment criteria
   if (config.hasAttachment !== undefined) {
     try {
@@ -202,6 +227,7 @@ async function checkExplicitRule(
   const hasCriteria = 
     config.subject !== undefined ||
     config.from !== undefined ||
+    config.to !== undefined ||
     config.hasAttachment !== undefined ||
     config.hasWords !== undefined;
 
@@ -235,7 +261,32 @@ function checkStringCriteria(
 }
 
 /**
- * Check email-based criteria (from) with wildcard support
+ * Collect recipient addresses for an email: the delivered-to address
+ * plus any addresses parsed from the To header (lowercased, deduplicated)
+ */
+function getRecipientAddresses(
+  email: typeof structuredEmails.$inferSelect
+): string[] {
+  const addresses = new Set<string>();
+
+  if (email.recipient) {
+    addresses.add(email.recipient.toLowerCase());
+  }
+
+  if (email.toData) {
+    const toData = JSON.parse(email.toData);
+    for (const addr of toData?.addresses || []) {
+      if (addr?.address) {
+        addresses.add(String(addr.address).toLowerCase());
+      }
+    }
+  }
+
+  return Array.from(addresses);
+}
+
+/**
+ * Check email-based criteria (from, to) with wildcard support
  */
 function checkEmailCriteria(
   emailAddresses: string[],
@@ -292,6 +343,13 @@ async function checkAiPromptRule(
     // ignore parse errors, treat as empty
   }
 
+  let toAddresses: string[] = [];
+  try {
+    toAddresses = getRecipientAddresses(email);
+  } catch {
+    // ignore parse errors, treat as empty
+  }
+
   let hasAttachments = false;
   try {
     const attachments = email.attachments ? JSON.parse(email.attachments) : [];
@@ -310,7 +368,7 @@ async function checkAiPromptRule(
       matches: z
         .array(
           z.object({
-            criteria: z.string().describe('subject | from | body | attachments | other'),
+            criteria: z.string().describe('subject | from | to | body | attachments | other'),
             value: z.string().describe('what content or pattern matched'),
           })
         )
@@ -326,6 +384,7 @@ Email:
         .map((a) => (a.name ? `${a.name} <${a.address || ''}>` : a.address || ''))
         .filter(Boolean)
         .join(', ')}
+- To: ${toAddresses.join(', ')}
 - Has attachments: ${hasAttachments ? 'yes' : 'no'}
 - Body (snippet):\n${bodySnippet}
 

--- a/lib/guard/rule-matcher.ts
+++ b/lib/guard/rule-matcher.ts
@@ -18,7 +18,7 @@ export interface GuardEvaluationResult {
   matchedRule?: GuardRule;
   action?: 'allow' | 'block' | 'route' | 'flag' | 'label';
   reason?: string;
-  metadata?: Record<string, any>;
+  metadata?: Record<string, unknown>;
 }
 
 /**
@@ -72,7 +72,7 @@ export async function checkRuleMatch(
     let config: ExplicitRuleConfig | AiPromptRuleConfig;
     try {
       config = JSON.parse(rule.config);
-    } catch (error) {
+    } catch {
       return {
         matched: false,
         error: 'Invalid rule configuration',
@@ -102,7 +102,7 @@ export async function checkRuleMatch(
 /**
  * Check if an explicit rule matches an email
  */
-async function checkExplicitRule(
+export async function checkExplicitRule(
   config: ExplicitRuleConfig,
   email: typeof structuredEmails.$inferSelect
 ): Promise<CheckRuleMatchResponse> {
@@ -131,10 +131,7 @@ async function checkExplicitRule(
   // Check from criteria
   if (config.from) {
     try {
-      const fromData = email.fromData ? JSON.parse(email.fromData) : null;
-      const fromAddresses = fromData?.addresses?.map((addr: any) => 
-        addr.address?.toLowerCase() || ''
-      ) || [];
+      const fromAddresses = getParsedHeaderAddresses(email.fromData);
       
       const fromMatches = checkEmailCriteria(
         fromAddresses,
@@ -261,28 +258,41 @@ function checkStringCriteria(
 }
 
 /**
- * Collect recipient addresses for an email: the delivered-to address
- * plus any addresses parsed from the To header (lowercased, deduplicated)
+ * Collect recipient addresses for an email from the delivered-to row recipient.
  */
 function getRecipientAddresses(
   email: typeof structuredEmails.$inferSelect
 ): string[] {
-  const addresses = new Set<string>();
-
-  if (email.recipient) {
-    addresses.add(email.recipient.toLowerCase());
+  const recipient = email.recipient?.trim().toLowerCase();
+  if (recipient) {
+    return [recipient];
   }
 
-  if (email.toData) {
-    const toData = JSON.parse(email.toData);
-    for (const addr of toData?.addresses || []) {
-      if (addr?.address) {
-        addresses.add(String(addr.address).toLowerCase());
-      }
+  return getParsedHeaderAddresses(email.toData);
+}
+
+function getParsedHeaderAddresses(addressData: string | null): string[] {
+  if (!addressData) {
+    return [];
+  }
+
+  const parsed: unknown = JSON.parse(addressData);
+  if (!isRecord(parsed) || !Array.isArray(parsed.addresses)) {
+    return [];
+  }
+
+  return parsed.addresses.flatMap((addr) => {
+    if (!isRecord(addr) || typeof addr.address !== "string") {
+      return [];
     }
-  }
 
-  return Array.from(addresses);
+    const address = addr.address.trim().toLowerCase();
+    return address ? [address] : [];
+  });
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
 }
 
 /**
@@ -410,7 +420,7 @@ Instructions:
         reason: object.reason,
         matches: object.matches,
       });
-    } catch (e) {
+    } catch {
       // ignore logging errors
     }
 
@@ -474,7 +484,7 @@ export async function evaluateGuardRules(
         let config: ExplicitRuleConfig | AiPromptRuleConfig;
         try {
           config = JSON.parse(rule.config);
-        } catch (error) {
+        } catch {
           console.error(`🛡️ Guard - Invalid config for rule ${rule.id}, skipping`)
           continue;
         }
@@ -496,7 +506,7 @@ export async function evaluateGuardRules(
           let actionConfig: RuleActionConfig;
           try {
             actionConfig = JSON.parse(rule.actions || '{"action":"allow"}');
-          } catch (error) {
+          } catch {
             console.error(`🛡️ Guard - Invalid action config for rule ${rule.id}, defaulting to allow`)
             actionConfig = { action: 'allow' };
           }


### PR DESCRIPTION
## Summary

Extends explicit Guard Rules with a new `to` criterion so rules can be scoped to specific recipient addresses (e.g. let a user create rules that only affect their own inbox) instead of applying account-wide.

```json
{ "to": { "operator": "OR", "values": ["me@mydomain.com"] } }
```

## Changes

**Matching** (`lib/guard/rule-matcher.ts`)
- New `config.to` block in `checkExplicitRule`, reusing the existing `checkEmailCriteria` helper — exact match and `*@domain.com` wildcards behave identically to `from`
- New `getRecipientAddresses()` helper: matches against the union of `structuredEmails.recipient` (actual delivered-to address, so BCC/alias deliveries are caught) and parsed `toData.addresses[]`, lowercased + deduplicated
- `hasCriteria` gate updated so a to-only rule is valid
- AI-prompt rules now receive a `To:` line in their LLM context for parity

**Types** (`features/guard/types/index.ts`)
- `to?: { operator: LogicOperator; values: string[] }` added to `ExplicitRuleConfig`

**AI rule generation** (`app/api/e2/guard/generate.ts`)
- `to` added to typebox response schema, zod generation schema, and the system prompt (with example)

**UI**
- Create page: new "To (Email Address)" section (OR/AND selector, multi-value inputs, wildcard hint), included in validation and config assembly
- Edit page: raw-JSON validator now structurally validates the `to` key

**Docs**
- Recipient addresses added to the criteria list in `content/blog/inbound-guard.mdx`

## Notes

- No DB migration — explicit-rule criteria live in the JSON `config` blob, and create/update endpoints accept `config` opaquely, so API clients can use this immediately
- `public/openapi.json` regenerated locally to confirm the new field appears (file is gitignored)
- Lint verified: no new errors vs. baseline on touched files

## Test plan

- [ ] Create an explicit rule with only a `to` criterion via UI — saves and shows on detail page
- [ ] `POST /api/e2/guard/{id}/check` with a structured email delivered to the matching address returns `matched: true`
- [ ] Wildcard `*@domain.com` in `to` matches any recipient on that domain
- [ ] Rule with `to` for address A does not match email delivered to address B
- [ ] `POST /api/e2/guard/generate` with "block emails sent to support@..." produces a `to` config

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes inbound Guard matching semantics for new `to` rules and alters which address is used for recipient checks; incorrect recipient data could mis-scope allow/block/route actions.
> 
> **Overview**
> Adds a **`to` recipient criterion** to explicit Guard rules so filtering can be scoped to specific inboxes (with OR/AND values and `*@domain.com` wildcards, same as `from`).
> 
> **Matching** evaluates `config.to` via `getRecipientAddresses()`, which prefers the stored **delivered** `structuredEmails.recipient` over visible `To` header addresses—so a rule for inbox A does not match when the message was delivered to inbox B. AI prompt evaluation and natural-language rule generation now understand `to` as well.
> 
> **UI** adds a “To (Email Address)” block on rule create, validation for to-only rules, and JSON structural checks on edit. Types and docs are updated; a unit test locks in delivered-recipient behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29442985f627fe301f460b5ac4795240ff845ca0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->