### PR TITLE
fix: normalize /api/v2 rewrite URLs so Elysia matches e2 routes

### DIFF
--- a/app/api/e2/[[...slugs]]/route.ts
+++ b/app/api/e2/[[...slugs]]/route.ts
@@ -505,11 +505,34 @@ https://inbound.new/api/e2
 	.use(checkGuardRule)
 	.use(generateGuardRules);
 
-export const GET = app.fetch;
-export const POST = app.fetch;
-export const PUT = app.fetch;
-export const PATCH = app.fetch;
-export const DELETE = app.fetch;
+// The /api/v2 -> /api/e2 rewrite in next.config.ts can deliver requests to
+// this handler with the original /api/v2 URL intact (behavior varies by
+// Vercel builder version). Normalize the path so Elysia (prefixed /api/e2)
+// matches regardless of which URL the platform passes through.
+const handler = (request: Request): Promise<Response> => {
+	const url = new URL(request.url);
+
+	if (url.pathname === "/api/v2" || url.pathname.startsWith("/api/v2/")) {
+		url.pathname = `/api/e2${url.pathname.slice("/api/v2".length)}`;
+
+		return app.fetch(
+			new Request(url, {
+				method: request.method,
+				headers: request.headers,
+				body: request.body,
+				duplex: "half",
+			} as RequestInit),
+		);
+	}
+
+	return app.fetch(request);
+};
+
+export const GET = handler;
+export const POST = handler;
+export const PUT = handler;
+export const PATCH = handler;
+export const DELETE = handler;
 
 export type App = typeof app;
 


### PR DESCRIPTION
## Problem

Since the Jun 11 production deploy (`9a8ffc4`), every `/api/v2/*` request returns **404 NOT_FOUND** — breaking the dashboard Guard page ("Failed to fetch guard rules") and all other clients of the deprecated-but-rewritten v2 API. The guard TanStack Query hooks fetch `/api/v2/guard*`.

## Root cause

Not the guard PR itself. Production hadn't deployed since **Apr 29** (`5268d5c`); merging #172 triggered the first build in 6 weeks:

| | Apr 29 (working) | Jun 11 (broken) |
|---|---|---|
| Vercel CLI (build) | 51.6.1 | 54.12.0 |
| Next.js | 16.1.6 | 16.1.6 |
| App code | `5268d5c` | `9a8ffc4` (guard files only) |

The newer Vercel builder delivers next.config-rewritten requests to the route handler with the **original** URL (`/api/v2/guard`) instead of the rewrite destination. Verified in prod: `/api/v2/guard` has `x-matched-path: /api/e2/[[...slugs]]` (rewrite works) but the body is Elysia's `NOT_FOUND` — the Elysia app is prefixed `/api/e2`, and `export const GET = app.fetch` passes the v2 URL straight through, so no route matches.

## Fix

Wrap the exported handlers: if `url.pathname` starts with `/api/v2`, rewrite it to `/api/e2` before calling `app.fetch` (method/headers/body forwarded, `duplex: "half"` for streamed bodies on Node). Robust regardless of which URL the platform passes — works on old and new Vercel builders and in `next dev`.

## Verification

In-memory tests against the imported handler (previously 404, now reach real endpoints):

- `GET /api/v2/guard` → 401 auth challenge from `guard/list.ts` (was 404)
- `GET /api/v2/guard?limit=5` → 401, query string preserved
- `POST /api/v2/guard` + JSON body → 401 from `guard/create.ts`, no duplex errors
- `GET /api/v2/domains` → 401 from `domains/list.ts`
- `GET /api/v2/does-not-exist` → 404 with the intended `deprecation_notice` JSON
- `GET /api/e2/guard` (direct) → 401, unchanged

Biome lint clean on the touched file.

## Post-merge check

```
curl -s -o /dev/null -w "%{http_code}" https://inbound.new/api/v2/guard   # expect 401, not 404
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the single entry point for all e2 API traffic and request forwarding; incorrect rewriting could break v2 compatibility or body handling on POST/PATCH.
> 
> **Overview**
> Fixes **404s on all `/api/v2/*` traffic** after newer Vercel builders started invoking the Elysia catch-all with the **original** `/api/v2` pathname instead of the rewritten `/api/e2` path, so routes under the `/api/e2` prefix never matched.
> 
> HTTP method exports (`GET`–`DELETE`) now go through a shared **`handler`** that rewrites `/api/v2` → `/api/e2` on the request URL, then forwards method, headers, and body (with **`duplex: "half"`** for streamed bodies) into `app.fetch`. Direct `/api/e2` requests are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13ed2797c820b037fec26f78c1c65085831e8f5e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->