### PR TITLE
docs: expand guard rule creation examples

### DIFF
--- a/app/api/e2/guard/create.ts
+++ b/app/api/e2/guard/create.ts
@@ -4,19 +4,189 @@ import { db } from "@/lib/db";
 import { guardRules } from "@/lib/db/schema";
 import { validateAndRateLimit } from "../lib/auth";
 
-// Request schema
-const CreateGuardRuleBody = t.Object({
-	name: t.String({ minLength: 1, description: "Rule name" }),
-	description: t.Optional(t.String({ description: "Rule description" })),
-	type: t.Union([t.Literal("explicit"), t.Literal("ai_prompt")], {
-		description: "Rule type",
-	}),
-	config: t.Any({ description: "Rule configuration (JSON)" }),
-	priority: t.Optional(
-		t.Number({ description: "Rule priority (higher = evaluated first)" }),
-	),
-	action: t.Optional(t.Any({ description: "Rule action configuration" })),
-});
+const GuardTextCriterionOpenApiSchema = {
+	type: "object",
+	required: ["operator", "values"],
+	properties: {
+		operator: {
+			type: "string",
+			enum: ["OR", "AND"],
+			description:
+				"OR matches any value; AND requires every value to match.",
+		},
+		values: {
+			type: "array",
+			minItems: 1,
+			items: { type: "string" },
+			description: "Case-insensitive substrings to match.",
+		},
+	},
+} as const;
+
+const GuardAddressCriterionOpenApiSchema = {
+	type: "object",
+	required: ["operator", "values"],
+	properties: {
+		operator: {
+			type: "string",
+			enum: ["OR", "AND"],
+			description:
+				"OR matches any address; AND requires every pattern to match.",
+		},
+		values: {
+			type: "array",
+			minItems: 1,
+			items: { type: "string" },
+			description:
+				"Exact email addresses or whole-domain patterns such as *@example.com.",
+		},
+	},
+} as const;
+
+const ExplicitRuleConfigOpenApiSchema = {
+	title: "Explicit rule configuration",
+	type: "object",
+	properties: {
+		mode: {
+			type: "string",
+			enum: ["simple", "advanced"],
+		},
+		subject: GuardTextCriterionOpenApiSchema,
+		from: GuardAddressCriterionOpenApiSchema,
+		to: GuardAddressCriterionOpenApiSchema,
+		hasAttachment: {
+			type: "boolean",
+			description: "Match emails based on whether they contain attachments.",
+		},
+		hasWords: GuardTextCriterionOpenApiSchema,
+	},
+} as const;
+
+const AiPromptRuleConfigOpenApiSchema = {
+	title: "AI prompt rule configuration",
+	type: "object",
+	required: ["prompt"],
+	properties: {
+		mode: {
+			type: "string",
+			enum: ["simple", "advanced"],
+		},
+		prompt: {
+			type: "string",
+			minLength: 1,
+			description: "Natural-language description of when the rule should match.",
+		},
+	},
+} as const;
+
+const GuardActionOpenApiSchemas = [
+	{
+		title: "Allow",
+		type: "object",
+		required: ["action"],
+		properties: { action: { const: "allow" } },
+	},
+	{
+		title: "Block",
+		type: "object",
+		required: ["action"],
+		properties: { action: { const: "block" } },
+	},
+	{
+		title: "Route",
+		type: "object",
+		required: ["action", "endpointId"],
+		properties: {
+			action: { const: "route" },
+			endpointId: {
+				type: "string",
+				description: "ID of an active endpoint owned by the account.",
+			},
+		},
+	},
+] as const;
+
+const CreateGuardRuleBody = t.Object(
+	{
+		name: t.String({
+			minLength: 1,
+			description: "A descriptive name for the rule.",
+		}),
+		description: t.Optional(
+			t.String({
+				description: "Optional explanation of what the rule handles.",
+			}),
+		),
+		type: t.Union([t.Literal("explicit"), t.Literal("ai_prompt")], {
+			description:
+				"Use explicit for deterministic criteria or ai_prompt for natural-language matching.",
+		}),
+		config: t.Any({
+			description:
+				"Configuration matching the selected rule type. See the request examples for complete explicit and AI configurations.",
+			oneOf: [
+				ExplicitRuleConfigOpenApiSchema,
+				AiPromptRuleConfigOpenApiSchema,
+			],
+		}),
+		priority: t.Optional(
+			t.Number({
+				description:
+					"Evaluation priority. Higher values run first; the first matching rule wins. Defaults to 0.",
+				default: 0,
+			}),
+		),
+		action: t.Optional(
+			t.Any({
+				description:
+					"Action to take when the rule matches: allow, block, or route to an owned endpoint. Defaults to allow when omitted.",
+				oneOf: GuardActionOpenApiSchemas,
+			}),
+		),
+	},
+	{
+		examples: [
+			{
+				name: "Block suspicious support invoices",
+				description: "Block invoice emails with attachments sent to support.",
+				type: "explicit",
+				priority: 100,
+				config: {
+					to: { operator: "OR", values: ["support@example.com"] },
+					subject: {
+						operator: "OR",
+						values: ["invoice", "payment overdue"],
+					},
+					hasAttachment: true,
+				},
+				action: { action: "block" },
+			},
+			{
+				name: "Route partner purchase orders",
+				type: "explicit",
+				priority: 50,
+				config: {
+					from: { operator: "OR", values: ["*@partner.example"] },
+					hasWords: {
+						operator: "AND",
+						values: ["purchase order", "account number"],
+					},
+				},
+				action: { action: "route", endpointId: "endpoint_123" },
+			},
+			{
+				name: "Block credential phishing",
+				type: "ai_prompt",
+				config: {
+					mode: "simple",
+					prompt:
+						"Match messages attempting to steal passwords, MFA codes, or login credentials.",
+				},
+				action: { action: "block" },
+			},
+		],
+	},
+);
 
 // Guard rule schema for response
 const GuardRuleSchema = t.Object({
@@ -36,10 +206,36 @@ const GuardRuleSchema = t.Object({
 });
 
 // Response schema - matches the envelope format expected by hooks
-const CreateGuardRuleResponse = t.Object({
-	success: t.Literal(true),
-	data: GuardRuleSchema,
-});
+const CreateGuardRuleResponse = t.Object(
+	{
+		success: t.Literal(true),
+		data: GuardRuleSchema,
+	},
+	{
+		description: "The newly created active guard rule.",
+		examples: [
+			{
+				success: true,
+				data: {
+					id: "V1StGXR8_Z5jdHi6B-myT",
+					userId: "user_123",
+					name: "Block suspicious support invoices",
+					description: "Block invoice emails with attachments sent to support.",
+					type: "explicit",
+					config:
+						'{"to":{"operator":"OR","values":["support@example.com"]},"subject":{"operator":"OR","values":["invoice","payment overdue"]},"hasAttachment":true}',
+					isActive: true,
+					priority: 100,
+					lastTriggeredAt: null,
+					triggerCount: 0,
+					actions: '{"action":"block"}',
+					createdAt: "2026-06-12T17:00:00.000Z",
+					updatedAt: "2026-06-12T17:00:00.000Z",
+				},
+			},
+		],
+	},
+);
 
 const ErrorResponse = t.Object({
 	error: t.String(),
@@ -136,7 +332,15 @@ export const createGuardRule = new Elysia().post(
 		detail: {
 			tags: ["Guard"],
 			summary: "Create guard rule",
-			description: "Create a new email filtering guard rule.",
+			description: `Create an active email filtering rule for the authenticated account.
+
+For an \`explicit\` rule, configure one or more of \`subject\`, \`from\`, \`to\`, \`hasAttachment\`, and \`hasWords\`. Different configured criteria are combined with AND. Within a criterion, \`OR\` matches any value and \`AND\` requires every value.
+
+Address criteria support exact, case-insensitive addresses and whole-domain patterns such as \`*@example.com\`. The \`to\` criterion matches the actual delivered recipient, which makes it suitable for limiting a rule to one inbox. Subject and body criteria use case-insensitive substring matching.
+
+Rules are evaluated from highest priority to lowest, and the first matching rule wins. A matching rule can \`allow\`, \`block\`, or \`route\` the email to an active endpoint owned by the account. If action is omitted, it defaults to \`allow\`.
+
+For an \`ai_prompt\` rule, provide a non-empty natural-language \`prompt\` describing when the rule should match.`,
 		},
 	},
 );


### PR DESCRIPTION
## Summary

Improves the generated [Create Guard Rule API reference](https://inbound.new/docs/api-reference/guard/create-guard-rule) with complete schemas, behavior details, and copy-ready examples.

The page is generated by Stainless from the Elysia OpenAPI schema, so this updates `app/api/e2/guard/create.ts` rather than adding an MDX page that would diverge from the API contract.

## Changes

- Documents both `explicit` and `ai_prompt` config shapes
- Documents all explicit criteria:
  - `subject`
  - `from`
  - `to` (including recipient-scoped rules)
  - `hasAttachment`
  - `hasWords`
- Explains matching behavior:
  - configured criteria combine with AND
  - OR/AND behavior within each criterion
  - exact addresses and `*@domain.com` wildcard support
  - case-insensitive substring matching
  - highest priority runs first; first matching rule wins
- Documents `allow`, `block`, and `route` action variants
- Adds three complete request examples:
  - recipient-scoped invoice block rule
  - partner purchase-order route rule
  - AI credential-phishing block rule
- Adds a complete `201` response example, including serialized `config` and `actions`
- Preserves the existing permissive runtime validation while enriching the generated OpenAPI schema

## Verification

- `bunx biome lint app/api/e2/guard/create.ts`
- `git diff --check`
- `bun run generate:openapi`
- Inspected `public/openapi.json` to confirm request examples, `config.oneOf`, `action.oneOf`, detailed description, and response example are present
- Confirmed legacy string `config`/`action` bodies still pass request validation and reach authentication (`401` unauthenticated), so this is documentation-only behaviorally

## Publishing note

After merge, the documented OpenAPI spec still needs to flow through the existing Stainless build/publish process before the hosted Mintlify page reflects the changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and OpenAPI metadata only; no changes to auth, persistence, or request validation behavior.
> 
> **Overview**
> Expands the **Create Guard Rule** OpenAPI contract in `app/api/e2/guard/create.ts` so Stainless/Mintlify can publish a fuller API reference, without tightening runtime validation (`config`/`action` remain `t.Any`).
> 
> Adds OpenAPI-only schema objects for explicit criteria (`subject`, `from`, `to`, `hasAttachment`, `hasWords`), `ai_prompt` config, and `allow` / `block` / `route` actions, wired via `oneOf` on the request body plus richer field descriptions. Includes three copy-ready request examples and a `201` response example with serialized `config` and `actions`.
> 
> The route `detail.description` now documents evaluation order, AND/OR matching, address wildcards, and default `allow` when action is omitted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd74cef972058f2942dd1434382951452f976c8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->