### PR TITLE
Add internal bulk email queue

### DIFF
--- a/app/api/e2/[[...slugs]]/route.ts
+++ b/app/api/e2/[[...slugs]]/route.ts
@@ -23,6 +23,9 @@ import { deleteEmailAddress } from "../email-addresses/delete";
 import { getEmailAddress } from "../email-addresses/get";
 import { listEmailAddresses } from "../email-addresses/list";
 import { updateEmailAddress } from "../email-addresses/update";
+import { cancelBulkEmailBatch } from "../emails/bulk-cancel";
+import { getBulkEmailBatch } from "../emails/bulk-get";
+import { sendBulkEmails } from "../emails/bulk-send";
 import { cancelEmail } from "../emails/cancel";
 import { getEmail } from "../emails/get";
 import { listEmails } from "../emails/list";
@@ -481,6 +484,9 @@ https://inbound.new/api/e2
 	.use(revokeCurrentApiKey)
 	// Email routes (sending, listing, managing)
 	.use(sendEmail)
+	.use(sendBulkEmails)
+	.use(getBulkEmailBatch)
+	.use(cancelBulkEmailBatch)
 	.use(listEmails)
 	.use(getEmail)
 	.use(updateEmail)

--- a/app/api/e2/emails/bulk-cancel.ts
+++ b/app/api/e2/emails/bulk-cancel.ts
@@ -1,0 +1,164 @@
+import { Client as QStashClient } from "@upstash/qstash";
+import { and, eq, inArray, sql } from "drizzle-orm";
+import { Elysia, t } from "elysia";
+import { db } from "@/lib/db";
+import {
+	BULK_EMAIL_ITEM_STATUS,
+	EMAIL_BATCH_STATUS,
+	emailBatches,
+	sentEmails,
+} from "@/lib/db/schema";
+import { authenticateEmailSend } from "../lib/send-auth";
+import { parseQstashMessageIdMap } from "./bulk-helpers";
+
+const BulkCancelResponse = t.Object({
+	id: t.String(),
+	status: t.String(),
+	total: t.Integer(),
+	cancelled_count: t.Integer(),
+	message: t.String(),
+});
+
+const ErrorResponse = t.Object({
+	error: t.String(),
+});
+
+export const cancelBulkEmailBatch = new Elysia().post(
+	"/emails/bulk/:id/cancel",
+	async ({ request, params, set }) => {
+		console.log(
+			"🗑️ POST /api/e2/emails/bulk/:id/cancel - Starting request for:",
+			params.id,
+		);
+
+		// Same credential surface as batch creation: full API keys/sessions
+		// (rate limited) and managed mail_/imap_ credentials, scoped to the
+		// owning user.
+		const { userId } = await authenticateEmailSend(request, set);
+
+		const [batch] = await db
+			.select()
+			.from(emailBatches)
+			.where(
+				and(eq(emailBatches.id, params.id), eq(emailBatches.userId, userId)),
+			)
+			.limit(1);
+
+		if (!batch) {
+			set.status = 404;
+			return { error: "Batch not found" };
+		}
+
+		// Atomic cancel: only unclaimed 'queued' items flip to 'cancelled'.
+		// Items already claimed by the worker (processing/sent/failed) are
+		// untouched — the worker's CAS claim skips cancelled rows.
+		const cancelledItems = await db
+			.update(sentEmails)
+			.set({
+				status: BULK_EMAIL_ITEM_STATUS.CANCELLED,
+				updatedAt: new Date(),
+			})
+			.where(
+				and(
+					eq(sentEmails.batchId, batch.id),
+					eq(sentEmails.userId, userId),
+					eq(sentEmails.status, BULK_EMAIL_ITEM_STATUS.QUEUED),
+				),
+			)
+			.returning({ id: sentEmails.id });
+
+		const cancelledCount = cancelledItems.length;
+		let finalStatus = batch.status;
+
+		if (cancelledCount > 0) {
+			finalStatus = EMAIL_BATCH_STATUS.CANCELLED;
+			await db
+				.update(emailBatches)
+				.set({
+					status: EMAIL_BATCH_STATUS.CANCELLED,
+					cancelledCount: sql`${emailBatches.cancelledCount} + ${cancelledCount}`,
+					updatedAt: new Date(),
+				})
+				.where(
+					and(
+						eq(emailBatches.id, batch.id),
+						inArray(emailBatches.status, [
+							EMAIL_BATCH_STATUS.QUEUED,
+							EMAIL_BATCH_STATUS.PARTIALLY_QUEUED,
+							EMAIL_BATCH_STATUS.CANCELLED,
+						]),
+					),
+				);
+
+			await db
+				.update(emailBatches)
+				.set({ completedAt: new Date() })
+				.where(
+					and(
+						eq(emailBatches.id, batch.id),
+						sql`${emailBatches.sentCount} + ${emailBatches.failedCount} + ${emailBatches.cancelledCount} >= ${emailBatches.total}`,
+					),
+				);
+
+			const messageIdMap = parseQstashMessageIdMap(batch.qstashMessageIds);
+			const messageIds = cancelledItems
+				.map((item) => messageIdMap[item.id])
+				.filter((messageId): messageId is string => Boolean(messageId));
+
+			if (messageIds.length > 0) {
+				try {
+					const qstashClient = new QStashClient({
+						token: process.env.QSTASH_TOKEN!,
+					});
+					const deleted = await qstashClient.messages.deleteMany(messageIds);
+					console.log(
+						`✅ Deleted ${deleted} queued QStash messages for batch:`,
+						batch.id,
+					);
+				} catch (qstashError) {
+					// Non-fatal: the worker's CAS claim ignores cancelled items,
+					// so an undeleted QStash delivery cannot cause a send.
+					console.error(
+						"⚠️ Failed to delete QStash messages (continuing):",
+						qstashError,
+					);
+				}
+			}
+		}
+
+		console.log("✅ Bulk batch cancel processed:", {
+			batchId: batch.id,
+			cancelledCount,
+			status: finalStatus,
+		});
+
+		return {
+			id: batch.id,
+			status: finalStatus,
+			total: batch.total,
+			cancelled_count: cancelledCount,
+			message:
+				cancelledCount > 0
+					? `Cancelled ${cancelledCount} queued email(s)`
+					: "No queued emails were eligible for cancellation",
+		};
+	},
+	{
+		params: t.Object({
+			id: t.String(),
+		}),
+		response: {
+			200: BulkCancelResponse,
+			401: ErrorResponse,
+			404: ErrorResponse,
+			500: ErrorResponse,
+		},
+		detail: {
+			hide: true,
+			tags: ["Emails"],
+			summary: "Cancel a bulk batch (internal)",
+			description:
+				"Cancels all still-queued items in a batch. Items already claimed, sent, failed, or cancelled are not affected.",
+		},
+	},
+);

--- a/app/api/e2/emails/bulk-get.ts
+++ b/app/api/e2/emails/bulk-get.ts
@@ -105,10 +105,14 @@ export const getBulkEmailBatch = new Elysia().get(
 		// Never-confirmed queued items (creator crashed before publishing).
 		// GET deliberately does not publish them — only an idempotent replay
 		// may — but the derived status below must not claim 'queued' either.
-		const unconfirmedQueued = countUnconfirmedQueuedItems(
+		let unconfirmedQueued = countUnconfirmedQueuedItems(
 			items,
 			parseQstashMessageIdMap(batch.qstashMessageIds),
 		);
+
+		// Parent row the response is built from; replaced with a fresh read
+		// after successful reconciliation below.
+		let responseBatch = batch;
 
 		// Abandonment recovery on status reads: items that were confirmed
 		// queued but whose delivery message is long overdue (retries
@@ -127,7 +131,37 @@ export const getBulkEmailBatch = new Elysia().get(
 						items,
 						includeMissing: false,
 					});
+
+					// Reconciliation may have merged new message ids and
+					// repaired the parent's advisory status / last_error
+					// (e.g. partially_queued -> queued). Re-read the parent
+					// and recompute the unconfirmed count from the fresh
+					// message-id map so the response reflects post-reconcile
+					// state instead of the stale snapshot. Items are not
+					// re-read: reconciliation never changes item status and
+					// only bumps updatedAt on still-queued rows, which no
+					// response field (including stale_processing, computed
+					// over 'processing' rows) depends on.
+					const [reconciledBatch] = await db
+						.select()
+						.from(emailBatches)
+						.where(
+							and(
+								eq(emailBatches.id, params.id),
+								eq(emailBatches.userId, userId),
+							),
+						)
+						.limit(1);
+					if (reconciledBatch) {
+						responseBatch = reconciledBatch;
+						unconfirmedQueued = countUnconfirmedQueuedItems(
+							items,
+							parseQstashMessageIdMap(reconciledBatch.qstashMessageIds),
+						);
+					}
 				} catch (reconcileError) {
+					// Best effort: on any reconcile/refresh failure the read
+					// still answers from the pre-reconcile snapshot.
 					console.error(
 						"⚠️ Bulk batch status reconciliation failed (continuing):",
 						reconcileError,
@@ -137,30 +171,34 @@ export const getBulkEmailBatch = new Elysia().get(
 		}
 
 		return {
-			id: batch.id,
+			id: responseBatch.id,
 			// Derived (not mutated): item rows are the source of truth, so a
 			// batch whose advisory status drifted still reads as completed
 			// once every item is terminal, and a stored 'queued' with
 			// never-published items reads as partially_queued. CANCELLED is
 			// preserved.
 			status: deriveBatchReadStatus(
-				batch.status,
+				responseBatch.status,
 				counts,
-				batch.total,
+				responseBatch.total,
 				unconfirmedQueued,
 			),
-			total: batch.total,
+			total: responseBatch.total,
 			counts,
 			...(staleProcessing > 0 && { stale_processing: staleProcessing }),
-			...(batch.scheduledAt && {
-				scheduled_at: formatScheduledDate(batch.scheduledAt),
-				timezone: batch.timezone || "UTC",
+			...(responseBatch.scheduledAt && {
+				scheduled_at: formatScheduledDate(responseBatch.scheduledAt),
+				timezone: responseBatch.timezone || "UTC",
 			}),
-			...(batch.createdAt && { created_at: batch.createdAt.toISOString() }),
-			...(batch.completedAt && {
-				completed_at: batch.completedAt.toISOString(),
+			...(responseBatch.createdAt && {
+				created_at: responseBatch.createdAt.toISOString(),
 			}),
-			...(batch.lastError && { last_error: batch.lastError }),
+			...(responseBatch.completedAt && {
+				completed_at: responseBatch.completedAt.toISOString(),
+			}),
+			...(responseBatch.lastError && {
+				last_error: responseBatch.lastError,
+			}),
 			data: items.map((item) => ({
 				id: item.id,
 				index: item.batchIndex ?? 0,

--- a/app/api/e2/emails/bulk-get.ts
+++ b/app/api/e2/emails/bulk-get.ts
@@ -1,0 +1,194 @@
+import { and, asc, eq } from "drizzle-orm";
+import { Elysia, t } from "elysia";
+import { db } from "@/lib/db";
+import { emailBatches, sentEmails } from "@/lib/db/schema";
+import { formatScheduledDate } from "@/lib/utils/date-parser";
+import { authenticateEmailSend } from "../lib/send-auth";
+import {
+	computeBatchCounts,
+	countStaleProcessingItems,
+	countUnconfirmedQueuedItems,
+	deriveBatchReadStatus,
+	parseQstashMessageIdMap,
+} from "./bulk-helpers";
+import { getBulkQueueConfig, reconcileBatchPublication } from "./bulk-queue";
+
+const BulkBatchItemSchema = t.Object({
+	id: t.String(),
+	index: t.Integer(),
+	status: t.String(),
+	from: t.String(),
+	subject: t.String(),
+	message_id: t.Optional(t.String()),
+	failure_reason: t.Optional(t.String()),
+	sent_at: t.Optional(t.String()),
+});
+
+const BulkBatchStatusResponse = t.Object({
+	id: t.String(),
+	status: t.String(),
+	total: t.Integer(),
+	counts: t.Object({
+		queued: t.Integer(),
+		processing: t.Integer(),
+		sent: t.Integer(),
+		failed: t.Integer(),
+		cancelled: t.Integer(),
+	}),
+	// Ops visibility only: items stuck in 'processing' beyond any
+	// legitimate worker lifetime. Never auto-requeued (could double-send).
+	stale_processing: t.Optional(t.Integer()),
+	scheduled_at: t.Optional(t.String()),
+	timezone: t.Optional(t.String()),
+	created_at: t.Optional(t.String()),
+	completed_at: t.Optional(t.String()),
+	last_error: t.Optional(t.String()),
+	data: t.Array(BulkBatchItemSchema),
+});
+
+const ErrorResponse = t.Object({
+	error: t.String(),
+});
+
+export const getBulkEmailBatch = new Elysia().get(
+	"/emails/bulk/:id",
+	async ({ request, params, set }) => {
+		console.log(
+			"📊 GET /api/e2/emails/bulk/:id - Starting request for:",
+			params.id,
+		);
+
+		// Same credential surface as batch creation: full API keys/sessions
+		// (rate limited) and managed mail_/imap_ credentials. The sender
+		// policy is irrelevant for reads; scoping stays per user.
+		const { userId } = await authenticateEmailSend(request, set);
+
+		const [batch] = await db
+			.select()
+			.from(emailBatches)
+			.where(
+				and(eq(emailBatches.id, params.id), eq(emailBatches.userId, userId)),
+			)
+			.limit(1);
+
+		if (!batch) {
+			set.status = 404;
+			return { error: "Batch not found" };
+		}
+
+		const items = await db
+			.select({
+				id: sentEmails.id,
+				batchIndex: sentEmails.batchIndex,
+				status: sentEmails.status,
+				from: sentEmails.from,
+				subject: sentEmails.subject,
+				messageId: sentEmails.messageId,
+				failureReason: sentEmails.failureReason,
+				sentAt: sentEmails.sentAt,
+				updatedAt: sentEmails.updatedAt,
+			})
+			.from(sentEmails)
+			.where(
+				and(eq(sentEmails.batchId, batch.id), eq(sentEmails.userId, userId)),
+			)
+			.orderBy(asc(sentEmails.batchIndex));
+
+		const counts = computeBatchCounts(items.map((item) => item.status));
+
+		// Stuck-claim visibility: claimed items untouched far beyond any
+		// worker lifetime (crashed mid-send, or sent but the success write
+		// failed). Surfaced for ops, never auto-requeued — a retry after an
+		// ambiguous SES hand-off could double-send.
+		const staleProcessing = countStaleProcessingItems(items, Date.now());
+
+		// Never-confirmed queued items (creator crashed before publishing).
+		// GET deliberately does not publish them — only an idempotent replay
+		// may — but the derived status below must not claim 'queued' either.
+		const unconfirmedQueued = countUnconfirmedQueuedItems(
+			items,
+			parseQstashMessageIdMap(batch.qstashMessageIds),
+		);
+
+		// Abandonment recovery on status reads: items that were confirmed
+		// queued but whose delivery message is long overdue (retries
+		// exhausted / DLQ'd) get a replacement published. Never publishes
+		// never-confirmed items (includeMissing: false) — a read must not
+		// start delivering emails the client was told were not queued — and
+		// never touches cancelled batches. Failures are swallowed: a status
+		// read must keep working even when the queue is down.
+		if (counts.queued > 0) {
+			const queueConfig = getBulkQueueConfig();
+			if (queueConfig) {
+				try {
+					await reconcileBatchPublication({
+						config: queueConfig,
+						batch,
+						items,
+						includeMissing: false,
+					});
+				} catch (reconcileError) {
+					console.error(
+						"⚠️ Bulk batch status reconciliation failed (continuing):",
+						reconcileError,
+					);
+				}
+			}
+		}
+
+		return {
+			id: batch.id,
+			// Derived (not mutated): item rows are the source of truth, so a
+			// batch whose advisory status drifted still reads as completed
+			// once every item is terminal, and a stored 'queued' with
+			// never-published items reads as partially_queued. CANCELLED is
+			// preserved.
+			status: deriveBatchReadStatus(
+				batch.status,
+				counts,
+				batch.total,
+				unconfirmedQueued,
+			),
+			total: batch.total,
+			counts,
+			...(staleProcessing > 0 && { stale_processing: staleProcessing }),
+			...(batch.scheduledAt && {
+				scheduled_at: formatScheduledDate(batch.scheduledAt),
+				timezone: batch.timezone || "UTC",
+			}),
+			...(batch.createdAt && { created_at: batch.createdAt.toISOString() }),
+			...(batch.completedAt && {
+				completed_at: batch.completedAt.toISOString(),
+			}),
+			...(batch.lastError && { last_error: batch.lastError }),
+			data: items.map((item) => ({
+				id: item.id,
+				index: item.batchIndex ?? 0,
+				status: item.status,
+				from: item.from,
+				subject: item.subject,
+				...(item.messageId && { message_id: item.messageId }),
+				...(item.failureReason && { failure_reason: item.failureReason }),
+				...(item.sentAt && { sent_at: item.sentAt.toISOString() }),
+			})),
+		};
+	},
+	{
+		params: t.Object({
+			id: t.String(),
+		}),
+		response: {
+			200: BulkBatchStatusResponse,
+			401: ErrorResponse,
+			404: ErrorResponse,
+			500: ErrorResponse,
+		},
+		detail: {
+			hide: true,
+			tags: ["Emails"],
+			summary: "Get bulk batch status (internal)",
+			description:
+				"Aggregate and per-item status for a bulk email batch. Item rows are the source of truth for counts.",
+		},
+	},
+);

--- a/app/api/e2/emails/bulk-helpers.test.ts
+++ b/app/api/e2/emails/bulk-helpers.test.ts
@@ -1,0 +1,921 @@
+import { describe, expect, it } from "bun:test";
+import {
+	attachmentsCacheKey,
+	BULK_CREATION_STALE_MS,
+	BULK_PROCESSING_STALE_MS,
+	BULK_PUBLICATION_ABANDONED_MS,
+	BULK_QSTASH_RETRIES,
+	BULK_QSTASH_RETRY_DELAY_EXPRESSION,
+	buildBulkAcceptedResponse,
+	buildBulkPublishRequest,
+	bulkDeduplicationId,
+	bulkFlowControlKey,
+	bulkHourlyRetryDeduplicationId,
+	bulkRepublishDeduplicationId,
+	collectItemRecipients,
+	computeBatchCounts,
+	computeHourlyLimitRetryAtSeconds,
+	countStaleProcessingItems,
+	countUnconfirmedQueuedItems,
+	deriveBatchReadStatus,
+	isBatchComplete,
+	isBulkItemCancellable,
+	isBulkItemClaimable,
+	isRetryableSesThrottlingError,
+	isStaleUnpublishedCreation,
+	MAX_BULK_EMAILS,
+	MAX_BULK_STORED_ATTACHMENT_BYTES,
+	mergeQstashMessageIdMaps,
+	parseQstashMessageIdMap,
+	resolveBatchStatusAfterPublish,
+	selectItemsNeedingPublication,
+	toAddressArray,
+	totalStoredAttachmentBytes,
+	validateBulkEmailItem,
+} from "@/app/api/e2/emails/bulk-helpers";
+import { BULK_EMAIL_ITEM_STATUS, EMAIL_BATCH_STATUS } from "@/lib/db/schema";
+
+const validItem = {
+	from: "Sender <sender@example.com>",
+	to: "to@example.com",
+	subject: "Hello",
+	text: "Hi there",
+};
+
+describe("validateBulkEmailItem", () => {
+	it("accepts a minimal valid item", () => {
+		expect(validateBulkEmailItem(validItem, 0)).toBeNull();
+	});
+
+	it("requires from, to, and subject", () => {
+		expect(validateBulkEmailItem({ ...validItem, from: "" }, 2)).toBe(
+			"emails[2]: from, to, and subject are required",
+		);
+		expect(validateBulkEmailItem({ ...validItem, subject: "" }, 5)).toContain(
+			"emails[5]",
+		);
+	});
+
+	it("requires html or text content", () => {
+		expect(validateBulkEmailItem({ ...validItem, text: undefined }, 1)).toBe(
+			"emails[1]: either html or text content must be provided",
+		);
+		expect(
+			validateBulkEmailItem(
+				{ ...validItem, text: undefined, html: "<p>hi</p>" },
+				1,
+			),
+		).toBeNull();
+	});
+
+	it("rejects empty recipient arrays", () => {
+		expect(validateBulkEmailItem({ ...validItem, to: [] }, 0)).toBe(
+			"emails[0]: exactly one 'to' recipient is required per bulk email (got 0)",
+		);
+	});
+
+	it("rejects more than one 'to' recipient per item", () => {
+		expect(
+			validateBulkEmailItem(
+				{ ...validItem, to: ["a@example.com", "b@example.com"] },
+				2,
+			),
+		).toBe(
+			"emails[2]: exactly one 'to' recipient is required per bulk email (got 2)",
+		);
+	});
+
+	it("accepts a single-element 'to' array", () => {
+		expect(
+			validateBulkEmailItem({ ...validItem, to: ["one@example.com"] }, 0),
+		).toBeNull();
+	});
+
+	it("rejects cc and bcc so every item stays one recipient", () => {
+		const expected =
+			"emails[1]: cc and bcc are not supported for bulk emails; send each recipient as its own email";
+		expect(validateBulkEmailItem({ ...validItem, cc: "c@d.co" }, 1)).toBe(
+			expected,
+		);
+		expect(validateBulkEmailItem({ ...validItem, bcc: ["e@f.co"] }, 1)).toBe(
+			expected,
+		);
+		// Empty arrays carry no recipients and are tolerated.
+		expect(validateBulkEmailItem({ ...validItem, cc: [], bcc: [] }, 1)).toBe(
+			null,
+		);
+	});
+
+	it("rejects invalid recipient addresses", () => {
+		expect(validateBulkEmailItem({ ...validItem, to: "not-an-email" }, 3)).toBe(
+			"emails[3]: invalid email format: not-an-email",
+		);
+		expect(validateBulkEmailItem({ ...validItem, to: ["bad@"] }, 4)).toContain(
+			"invalid email format",
+		);
+	});
+
+	it("accepts display-name recipients", () => {
+		expect(
+			validateBulkEmailItem(
+				{ ...validItem, to: "Jane Doe <jane@example.com>" },
+				0,
+			),
+		).toBeNull();
+	});
+});
+
+describe("recipient helpers", () => {
+	it("normalizes single values and arrays", () => {
+		expect(toAddressArray(undefined)).toEqual([]);
+		expect(toAddressArray("a@b.co")).toEqual(["a@b.co"]);
+		expect(toAddressArray(["a@b.co", "c@d.co"])).toEqual(["a@b.co", "c@d.co"]);
+	});
+
+	it("collects to, cc, and bcc recipients", () => {
+		expect(
+			collectItemRecipients({
+				...validItem,
+				to: ["a@b.co"],
+				cc: "c@d.co",
+				bcc: ["e@f.co"],
+			}),
+		).toEqual(["a@b.co", "c@d.co", "e@f.co"]);
+	});
+});
+
+describe("buildBulkPublishRequest", () => {
+	it("queues durable IDs only - no message content", () => {
+		const request = buildBulkPublishRequest({
+			webhookUrl: "https://app.example.com/api/webhooks/send-email",
+			emailId: "email_1",
+			userId: "user_1",
+			batchId: "batch_1",
+			batchIndex: 3,
+		});
+
+		expect(request.body).toEqual({
+			type: "batch",
+			emailId: "email_1",
+			userId: "user_1",
+			batchId: "batch_1",
+			batchIndex: 3,
+		});
+		expect(Object.keys(request.body)).not.toContain("emailData");
+		expect(request.retries).toBe(BULK_QSTASH_RETRIES);
+		expect(request.retryDelay).toBe(BULK_QSTASH_RETRY_DELAY_EXPRESSION);
+		expect(request.notBefore).toBeUndefined();
+	});
+
+	it("spaces retries out far enough to ride through transient outages", () => {
+		// The expression must reference the retry counter and stay in ms.
+		expect(BULK_QSTASH_RETRIES).toBeGreaterThanOrEqual(5);
+		expect(BULK_QSTASH_RETRY_DELAY_EXPRESSION).toContain("retried");
+		// Abandonment must not trigger while QStash retries are still
+		// possible: 5 delays capped at 30 minutes each stay well under 2h.
+		expect(BULK_PUBLICATION_ABANDONED_MS).toBeGreaterThanOrEqual(
+			2 * 60 * 60 * 1000,
+		);
+	});
+
+	it("allows a deduplication override for recovery republishes", () => {
+		const request = buildBulkPublishRequest({
+			webhookUrl: "https://app.example.com/api/webhooks/send-email",
+			emailId: "email_1",
+			userId: "user_1",
+			batchId: "batch_1",
+			batchIndex: 0,
+			deduplicationId: "bulk_email_1_r123",
+		});
+
+		expect(request.deduplicationId).toBe("bulk_email_1_r123");
+	});
+
+	it("serializes worker flow per user and dedupes per item", () => {
+		const request = buildBulkPublishRequest({
+			webhookUrl: "https://app.example.com/api/webhooks/send-email",
+			emailId: "email_9",
+			userId: "user_7",
+			batchId: "batch_2",
+			batchIndex: 0,
+		});
+
+		expect(request.flowControl).toEqual({
+			key: bulkFlowControlKey("user_7"),
+			parallelism: 1,
+		});
+		expect(request.deduplicationId).toBe(bulkDeduplicationId("email_9"));
+	});
+
+	it("propagates notBefore for scheduled batches", () => {
+		const notBefore = 1_900_000_000;
+		const request = buildBulkPublishRequest({
+			webhookUrl: "https://app.example.com/api/webhooks/send-email",
+			emailId: "email_2",
+			userId: "user_1",
+			batchId: "batch_1",
+			batchIndex: 1,
+			notBefore,
+		});
+
+		expect(request.notBefore).toBe(notBefore);
+	});
+});
+
+describe("batch aggregation", () => {
+	it("computes counts from item statuses", () => {
+		expect(
+			computeBatchCounts([
+				BULK_EMAIL_ITEM_STATUS.QUEUED,
+				BULK_EMAIL_ITEM_STATUS.QUEUED,
+				BULK_EMAIL_ITEM_STATUS.PROCESSING,
+				BULK_EMAIL_ITEM_STATUS.SENT,
+				BULK_EMAIL_ITEM_STATUS.FAILED,
+				BULK_EMAIL_ITEM_STATUS.CANCELLED,
+				null,
+			]),
+		).toEqual({
+			queued: 2,
+			processing: 1,
+			sent: 1,
+			failed: 1,
+			cancelled: 1,
+		});
+	});
+
+	it("marks a batch complete only when all items are terminal", () => {
+		expect(
+			isBatchComplete(
+				{ queued: 0, processing: 0, sent: 2, failed: 1, cancelled: 1 },
+				4,
+			),
+		).toBe(true);
+		expect(
+			isBatchComplete(
+				{ queued: 1, processing: 0, sent: 2, failed: 1, cancelled: 0 },
+				4,
+			),
+		).toBe(false);
+		expect(
+			isBatchComplete(
+				{ queued: 0, processing: 1, sent: 3, failed: 0, cancelled: 0 },
+				4,
+			),
+		).toBe(false);
+	});
+
+	it("resolves post-publish batch status honestly", () => {
+		// Status is driven by unconfirmed queued items, not raw publish counts.
+		expect(resolveBatchStatusAfterPublish(0)).toBe(EMAIL_BATCH_STATUS.QUEUED);
+		expect(resolveBatchStatusAfterPublish(1)).toBe(
+			EMAIL_BATCH_STATUS.PARTIALLY_QUEUED,
+		);
+		expect(resolveBatchStatusAfterPublish(10)).toBe(
+			EMAIL_BATCH_STATUS.PARTIALLY_QUEUED,
+		);
+	});
+});
+
+describe("claim and cancel eligibility", () => {
+	it("only queued items are claimable by the worker", () => {
+		expect(isBulkItemClaimable(BULK_EMAIL_ITEM_STATUS.QUEUED)).toBe(true);
+		expect(isBulkItemClaimable(BULK_EMAIL_ITEM_STATUS.PROCESSING)).toBe(false);
+		expect(isBulkItemClaimable(BULK_EMAIL_ITEM_STATUS.SENT)).toBe(false);
+		expect(isBulkItemClaimable(BULK_EMAIL_ITEM_STATUS.FAILED)).toBe(false);
+		expect(isBulkItemClaimable(BULK_EMAIL_ITEM_STATUS.CANCELLED)).toBe(false);
+		expect(isBulkItemClaimable(null)).toBe(false);
+	});
+
+	it("only queued (unclaimed) items are cancellable", () => {
+		expect(isBulkItemCancellable(BULK_EMAIL_ITEM_STATUS.QUEUED)).toBe(true);
+		expect(isBulkItemCancellable(BULK_EMAIL_ITEM_STATUS.PROCESSING)).toBe(
+			false,
+		);
+		expect(isBulkItemCancellable(BULK_EMAIL_ITEM_STATUS.SENT)).toBe(false);
+	});
+});
+
+describe("idempotent replay response", () => {
+	const batch = {
+		id: "batch_1",
+		status: EMAIL_BATCH_STATUS.QUEUED,
+		total: 3,
+		scheduledAt: null,
+		timezone: null,
+	};
+
+	it("returns a deterministic shape ordered by batch index", () => {
+		const items = [
+			{ id: "email_c", batchIndex: 2 },
+			{ id: "email_a", batchIndex: 0 },
+			{ id: "email_b", batchIndex: 1 },
+		];
+
+		const first = buildBulkAcceptedResponse(batch, items);
+		const second = buildBulkAcceptedResponse(batch, [...items].reverse());
+
+		expect(first).toEqual(second);
+		expect(first.data.map((item) => item.id)).toEqual([
+			"email_a",
+			"email_b",
+			"email_c",
+		]);
+		expect(first.scheduled_at).toBeUndefined();
+	});
+
+	it("includes batch-level schedule information when present", () => {
+		const scheduledAt = new Date("2026-08-09T10:00:00.000Z");
+		const response = buildBulkAcceptedResponse(
+			{ ...batch, scheduledAt, timezone: "America/New_York" },
+			[{ id: "email_a", batchIndex: 0 }],
+		);
+
+		expect(response.scheduled_at).toBe(scheduledAt.toISOString());
+		expect(response.timezone).toBe("America/New_York");
+	});
+});
+
+describe("attachment dedup cache key", () => {
+	it("is stable for identical attachment lists", () => {
+		const attachments = [
+			{
+				filename: "a.pdf",
+				content: "aGVsbG8=",
+				content_type: "application/pdf",
+			},
+		];
+		expect(attachmentsCacheKey(attachments)).toBe(
+			attachmentsCacheKey([...attachments]),
+		);
+	});
+
+	it("differs when content differs", () => {
+		expect(
+			attachmentsCacheKey([{ filename: "a.pdf", content: "aGVsbG8=" }]),
+		).not.toBe(
+			attachmentsCacheKey([{ filename: "a.pdf", content: "d29ybGQ=" }]),
+		);
+	});
+
+	it("treats missing and empty attachment lists the same", () => {
+		expect(attachmentsCacheKey(undefined)).toBe(attachmentsCacheKey([]));
+	});
+});
+
+describe("parseQstashMessageIdMap", () => {
+	it("parses a valid map", () => {
+		expect(
+			parseQstashMessageIdMap('{"email_1":"msg_1","email_2":"msg_2"}'),
+		).toEqual({ email_1: "msg_1", email_2: "msg_2" });
+	});
+
+	it("returns an empty map for null, invalid JSON, and non-objects", () => {
+		expect(parseQstashMessageIdMap(null)).toEqual({});
+		expect(parseQstashMessageIdMap("not json")).toEqual({});
+		expect(parseQstashMessageIdMap('["msg_1"]')).toEqual({});
+	});
+
+	it("drops non-string values", () => {
+		expect(parseQstashMessageIdMap('{"email_1":"msg_1","email_2":7}')).toEqual({
+			email_1: "msg_1",
+		});
+	});
+});
+
+describe("stored attachment accounting", () => {
+	it("sums serialized bytes across rows, counting duplicates per row", () => {
+		const serialized = JSON.stringify([
+			{
+				content: "aGVsbG8=",
+				filename: "a.pdf",
+				content_type: "application/pdf",
+			},
+		]);
+		const rowBytes = Buffer.byteLength(serialized, "utf8");
+
+		expect(
+			totalStoredAttachmentBytes([serialized, serialized, serialized]),
+		).toBe(rowBytes * 3);
+	});
+
+	it("skips rows without attachments", () => {
+		const serialized = '[{"content":"aGVsbG8=","filename":"a.txt"}]';
+		expect(totalStoredAttachmentBytes([null, serialized, null])).toBe(
+			Buffer.byteLength(serialized, "utf8"),
+		);
+		expect(totalStoredAttachmentBytes([])).toBe(0);
+		expect(totalStoredAttachmentBytes([null, null])).toBe(0);
+	});
+
+	it("measures UTF-8 bytes, not string length", () => {
+		const multibyte = '[{"filename":"héllo–✓.txt","content":"aGVsbG8="}]';
+		expect(totalStoredAttachmentBytes([multibyte])).toBe(
+			Buffer.byteLength(multibyte, "utf8"),
+		);
+		expect(totalStoredAttachmentBytes([multibyte])).toBeGreaterThan(
+			multibyte.length,
+		);
+	});
+});
+
+describe("isRetryableSesThrottlingError", () => {
+	it("classifies known SES throttling names as retryable", () => {
+		expect(
+			isRetryableSesThrottlingError({ name: "TooManyRequestsException" }),
+		).toBe(true);
+		expect(isRetryableSesThrottlingError({ name: "ThrottlingException" })).toBe(
+			true,
+		);
+	});
+
+	it("classifies HTTP 429 responses as retryable", () => {
+		expect(
+			isRetryableSesThrottlingError({
+				name: "UnknownError",
+				$metadata: { httpStatusCode: 429 },
+			}),
+		).toBe(true);
+	});
+
+	it("classifies explicit throttling retry metadata as retryable", () => {
+		expect(
+			isRetryableSesThrottlingError({
+				name: "SomethingElse",
+				$retryable: { throttling: true },
+			}),
+		).toBe(true);
+	});
+
+	it("does not classify generic network or timeout errors as retryable", () => {
+		expect(isRetryableSesThrottlingError(new Error("socket hang up"))).toBe(
+			false,
+		);
+		expect(isRetryableSesThrottlingError({ name: "TimeoutError" })).toBe(false);
+		expect(
+			isRetryableSesThrottlingError({ name: "ECONNRESET", code: "ECONNRESET" }),
+		).toBe(false);
+	});
+
+	it("does not treat non-throttling retryable metadata or 5xx as safe", () => {
+		expect(isRetryableSesThrottlingError({ $retryable: {} })).toBe(false);
+		expect(
+			isRetryableSesThrottlingError({
+				name: "InternalServiceErrorException",
+				$metadata: { httpStatusCode: 500 },
+			}),
+		).toBe(false);
+	});
+
+	it("handles non-object inputs", () => {
+		expect(isRetryableSesThrottlingError(null)).toBe(false);
+		expect(isRetryableSesThrottlingError(undefined)).toBe(false);
+		expect(isRetryableSesThrottlingError("throttled")).toBe(false);
+		expect(isRetryableSesThrottlingError(429)).toBe(false);
+	});
+});
+
+describe("deriveBatchReadStatus", () => {
+	const allTerminal = {
+		queued: 0,
+		processing: 0,
+		sent: 3,
+		failed: 1,
+		cancelled: 1,
+	};
+	const inFlight = {
+		queued: 1,
+		processing: 1,
+		sent: 3,
+		failed: 0,
+		cancelled: 0,
+	};
+
+	it("reports completion when items are all terminal but parent drifted", () => {
+		expect(
+			deriveBatchReadStatus(EMAIL_BATCH_STATUS.QUEUED, allTerminal, 5),
+		).toBe(EMAIL_BATCH_STATUS.COMPLETED);
+		expect(
+			deriveBatchReadStatus(
+				EMAIL_BATCH_STATUS.PARTIALLY_QUEUED,
+				allTerminal,
+				5,
+			),
+		).toBe(EMAIL_BATCH_STATUS.COMPLETED);
+	});
+
+	it("preserves CANCELLED even when all items are terminal", () => {
+		expect(
+			deriveBatchReadStatus(EMAIL_BATCH_STATUS.CANCELLED, allTerminal, 5),
+		).toBe(EMAIL_BATCH_STATUS.CANCELLED);
+	});
+
+	it("keeps the stored status while items are still in flight", () => {
+		expect(deriveBatchReadStatus(EMAIL_BATCH_STATUS.QUEUED, inFlight, 5)).toBe(
+			EMAIL_BATCH_STATUS.QUEUED,
+		);
+		expect(
+			deriveBatchReadStatus(EMAIL_BATCH_STATUS.PARTIALLY_QUEUED, inFlight, 5),
+		).toBe(EMAIL_BATCH_STATUS.PARTIALLY_QUEUED);
+	});
+
+	it("keeps COMPLETED stable and ignores empty totals", () => {
+		expect(
+			deriveBatchReadStatus(EMAIL_BATCH_STATUS.COMPLETED, allTerminal, 5),
+		).toBe(EMAIL_BATCH_STATUS.COMPLETED);
+		expect(
+			deriveBatchReadStatus(
+				EMAIL_BATCH_STATUS.QUEUED,
+				{ queued: 0, processing: 0, sent: 0, failed: 0, cancelled: 0 },
+				0,
+			),
+		).toBe(EMAIL_BATCH_STATUS.QUEUED);
+	});
+
+	it("does not report completion during the creation window (items < total)", () => {
+		expect(
+			deriveBatchReadStatus(
+				EMAIL_BATCH_STATUS.QUEUED,
+				{ queued: 0, processing: 0, sent: 2, failed: 0, cancelled: 0 },
+				5,
+			),
+		).toBe(EMAIL_BATCH_STATUS.QUEUED);
+	});
+
+	it("demotes a stored 'queued' to partially_queued when queued items were never published", () => {
+		// Creator crashed before confirming publications: the parent still
+		// says 'queued' but some items were never handed to the queue.
+		expect(
+			deriveBatchReadStatus(EMAIL_BATCH_STATUS.QUEUED, inFlight, 5, 1),
+		).toBe(EMAIL_BATCH_STATUS.PARTIALLY_QUEUED);
+		expect(
+			deriveBatchReadStatus(EMAIL_BATCH_STATUS.QUEUED, inFlight, 5, 0),
+		).toBe(EMAIL_BATCH_STATUS.QUEUED);
+	});
+
+	it("keeps unconfirmed-publication demotion subordinate to sticky and terminal states", () => {
+		// partially_queued is already honest.
+		expect(
+			deriveBatchReadStatus(
+				EMAIL_BATCH_STATUS.PARTIALLY_QUEUED,
+				inFlight,
+				5,
+				2,
+			),
+		).toBe(EMAIL_BATCH_STATUS.PARTIALLY_QUEUED);
+		// CANCELLED records a user decision and always wins.
+		expect(
+			deriveBatchReadStatus(EMAIL_BATCH_STATUS.CANCELLED, inFlight, 5, 2),
+		).toBe(EMAIL_BATCH_STATUS.CANCELLED);
+		// All-terminal item rows win (unconfirmed queued cannot coexist).
+		expect(
+			deriveBatchReadStatus(EMAIL_BATCH_STATUS.QUEUED, allTerminal, 5, 2),
+		).toBe(EMAIL_BATCH_STATUS.COMPLETED);
+	});
+});
+
+describe("countStaleProcessingItems", () => {
+	const nowMs = 1_700_000_000_000;
+	const stale = new Date(nowMs - BULK_PROCESSING_STALE_MS - 60_000);
+	const fresh = new Date(nowMs - 60_000);
+
+	it("counts only processing items untouched beyond the stale horizon", () => {
+		expect(
+			countStaleProcessingItems(
+				[
+					{ status: BULK_EMAIL_ITEM_STATUS.PROCESSING, updatedAt: stale },
+					{ status: BULK_EMAIL_ITEM_STATUS.PROCESSING, updatedAt: fresh },
+					{ status: BULK_EMAIL_ITEM_STATUS.QUEUED, updatedAt: stale },
+					{ status: BULK_EMAIL_ITEM_STATUS.SENT, updatedAt: stale },
+					{ status: BULK_EMAIL_ITEM_STATUS.FAILED, updatedAt: stale },
+					{ status: BULK_EMAIL_ITEM_STATUS.CANCELLED, updatedAt: stale },
+				],
+				nowMs,
+			),
+		).toBe(1);
+	});
+
+	it("is conservative at the boundary and for missing timestamps", () => {
+		// Exactly at the horizon is not yet stale (must be strictly past).
+		expect(
+			countStaleProcessingItems(
+				[
+					{
+						status: BULK_EMAIL_ITEM_STATUS.PROCESSING,
+						updatedAt: new Date(nowMs - BULK_PROCESSING_STALE_MS),
+					},
+				],
+				nowMs,
+			),
+		).toBe(0);
+		// A missing updatedAt says nothing about staleness — never guessed.
+		expect(
+			countStaleProcessingItems(
+				[{ status: BULK_EMAIL_ITEM_STATUS.PROCESSING, updatedAt: null }],
+				nowMs,
+			),
+		).toBe(0);
+		expect(countStaleProcessingItems([], nowMs)).toBe(0);
+	});
+
+	it("uses a horizon safely beyond the maximum serverless lifetime", () => {
+		expect(BULK_PROCESSING_STALE_MS).toBe(45 * 60 * 1000);
+	});
+});
+
+describe("recovery deduplication ids", () => {
+	it("versions republish ids by 10-minute bucket so retries collapse but recovery is never swallowed", () => {
+		// Align to a bucket boundary so the +9min case stays in-bucket.
+		const base = Math.floor(1_700_000_000_000 / 600_000) * 600_000;
+		expect(bulkRepublishDeduplicationId("email_1", base)).toBe(
+			bulkRepublishDeduplicationId("email_1", base + 9 * 60 * 1000),
+		);
+		expect(bulkRepublishDeduplicationId("email_1", base)).not.toBe(
+			bulkRepublishDeduplicationId("email_1", base + 11 * 60 * 1000),
+		);
+		// Never collides with the original publication id.
+		expect(bulkRepublishDeduplicationId("email_1", base)).not.toBe(
+			bulkDeduplicationId("email_1"),
+		);
+	});
+
+	it("includes the retry time in hourly reschedule ids", () => {
+		expect(bulkHourlyRetryDeduplicationId("email_1", 1_700_000_000)).toBe(
+			"bulk_email_1_h1700000000",
+		);
+		expect(bulkHourlyRetryDeduplicationId("email_1", 1_700_000_000)).not.toBe(
+			bulkHourlyRetryDeduplicationId("email_1", 1_700_003_600),
+		);
+		expect(bulkHourlyRetryDeduplicationId("email_1", 1_700_000_000)).not.toBe(
+			bulkDeduplicationId("email_1"),
+		);
+	});
+});
+
+describe("computeHourlyLimitRetryAtSeconds", () => {
+	it("schedules past the full rolling hour plus a buffer", () => {
+		const nowMs = 1_700_000_000_000;
+		const retryAt = computeHourlyLimitRetryAtSeconds(nowMs);
+		const nowSeconds = nowMs / 1000;
+		expect(retryAt).toBeGreaterThanOrEqual(nowSeconds + 3600);
+		expect(retryAt).toBeLessThanOrEqual(nowSeconds + 2 * 3600);
+	});
+});
+
+describe("isStaleUnpublishedCreation", () => {
+	const nowMs = 1_700_000_000_000;
+	const base = {
+		batchStatus: EMAIL_BATCH_STATUS.QUEUED,
+		batchTotal: 10,
+		itemCount: 4,
+		messageIdMap: {},
+		nowMs,
+	};
+
+	it("treats an old partial creation with no publications as stale", () => {
+		expect(
+			isStaleUnpublishedCreation({
+				...base,
+				batchCreatedAt: new Date(nowMs - BULK_CREATION_STALE_MS - 1000),
+			}),
+		).toBe(true);
+	});
+
+	it("keeps fresh partial creations (still being inserted) alive", () => {
+		expect(
+			isStaleUnpublishedCreation({
+				...base,
+				batchCreatedAt: new Date(nowMs - 30_000),
+			}),
+		).toBe(false);
+	});
+
+	it("never treats a fully created batch as stale", () => {
+		expect(
+			isStaleUnpublishedCreation({
+				...base,
+				itemCount: 10,
+				batchCreatedAt: new Date(nowMs - 10 * BULK_CREATION_STALE_MS),
+			}),
+		).toBe(false);
+	});
+
+	it("never cleans up once any publication was recorded", () => {
+		expect(
+			isStaleUnpublishedCreation({
+				...base,
+				messageIdMap: { email_1: "msg_1" },
+				batchCreatedAt: new Date(nowMs - 10 * BULK_CREATION_STALE_MS),
+			}),
+		).toBe(false);
+	});
+
+	it("never cleans up cancelled batches", () => {
+		expect(
+			isStaleUnpublishedCreation({
+				...base,
+				batchStatus: EMAIL_BATCH_STATUS.CANCELLED,
+				batchCreatedAt: new Date(nowMs - 10 * BULK_CREATION_STALE_MS),
+			}),
+		).toBe(false);
+	});
+});
+
+describe("selectItemsNeedingPublication", () => {
+	const nowMs = 1_700_000_000_000;
+	const old = new Date(nowMs - BULK_PUBLICATION_ABANDONED_MS - 60_000);
+	const recent = new Date(nowMs - 60_000);
+
+	const queuedItem = (id: string, updatedAt: Date, batchIndex = 0) => ({
+		id,
+		batchIndex,
+		status: BULK_EMAIL_ITEM_STATUS.QUEUED,
+		updatedAt,
+	});
+
+	it("republishes never-confirmed items only on explicit replays", () => {
+		const items = [queuedItem("email_1", recent)];
+
+		const onReplay = selectItemsNeedingPublication({
+			items,
+			messageIdMap: {},
+			batchScheduledAt: null,
+			batchCreatedAt: new Date(nowMs - 5 * 60 * 1000),
+			nowMs,
+			includeMissing: true,
+		});
+		expect(onReplay).toHaveLength(1);
+		expect(onReplay[0]).toMatchObject({ id: "email_1", reason: "missing" });
+		expect(onReplay[0].deduplicationId).toBe(
+			bulkRepublishDeduplicationId("email_1", nowMs),
+		);
+
+		// A status read must never start delivering never-confirmed items.
+		const onStatusRead = selectItemsNeedingPublication({
+			items,
+			messageIdMap: {},
+			batchScheduledAt: null,
+			batchCreatedAt: new Date(nowMs - 5 * 60 * 1000),
+			nowMs,
+			includeMissing: false,
+		});
+		expect(onStatusRead).toHaveLength(0);
+	});
+
+	it("recovers abandoned confirmed publications on both replays and status reads", () => {
+		const items = [queuedItem("email_1", old)];
+		const messageIdMap = { email_1: "msg_1" };
+		const batchCreatedAt = new Date(
+			nowMs - BULK_PUBLICATION_ABANDONED_MS - 120_000,
+		);
+
+		for (const includeMissing of [true, false]) {
+			const selected = selectItemsNeedingPublication({
+				items,
+				messageIdMap,
+				batchScheduledAt: null,
+				batchCreatedAt,
+				nowMs,
+				includeMissing,
+			});
+			expect(selected).toHaveLength(1);
+			expect(selected[0].reason).toBe("abandoned");
+		}
+	});
+
+	it("does not treat recently touched or recently due items as abandoned", () => {
+		// Touched recently (worker requeue bumps updatedAt).
+		expect(
+			selectItemsNeedingPublication({
+				items: [queuedItem("email_1", recent)],
+				messageIdMap: { email_1: "msg_1" },
+				batchScheduledAt: null,
+				batchCreatedAt: new Date(nowMs - BULK_PUBLICATION_ABANDONED_MS * 2),
+				nowMs,
+				includeMissing: true,
+			}),
+		).toHaveLength(0);
+
+		// Batch only just became due.
+		expect(
+			selectItemsNeedingPublication({
+				items: [queuedItem("email_1", old)],
+				messageIdMap: { email_1: "msg_1" },
+				batchScheduledAt: new Date(nowMs - 60_000),
+				batchCreatedAt: new Date(nowMs - BULK_PUBLICATION_ABANDONED_MS * 2),
+				nowMs,
+				includeMissing: true,
+			}),
+		).toHaveLength(0);
+	});
+
+	it("never treats future-scheduled batches as abandoned", () => {
+		expect(
+			selectItemsNeedingPublication({
+				items: [queuedItem("email_1", old)],
+				messageIdMap: { email_1: "msg_1" },
+				batchScheduledAt: new Date(nowMs + 60 * 60 * 1000),
+				batchCreatedAt: old,
+				nowMs,
+				includeMissing: true,
+			}),
+		).toHaveLength(0);
+	});
+
+	it("still republishes missing items of future-scheduled batches on replay", () => {
+		const selected = selectItemsNeedingPublication({
+			items: [queuedItem("email_1", recent)],
+			messageIdMap: {},
+			batchScheduledAt: new Date(nowMs + 60 * 60 * 1000),
+			batchCreatedAt: recent,
+			nowMs,
+			includeMissing: true,
+		});
+		expect(selected).toHaveLength(1);
+		expect(selected[0].reason).toBe("missing");
+	});
+
+	it("skips cancelled, processing, and terminal items entirely", () => {
+		const items = [
+			{
+				id: "email_1",
+				batchIndex: 0,
+				status: BULK_EMAIL_ITEM_STATUS.CANCELLED,
+				updatedAt: old,
+			},
+			{
+				id: "email_2",
+				batchIndex: 1,
+				status: BULK_EMAIL_ITEM_STATUS.PROCESSING,
+				updatedAt: old,
+			},
+			{
+				id: "email_3",
+				batchIndex: 2,
+				status: BULK_EMAIL_ITEM_STATUS.SENT,
+				updatedAt: old,
+			},
+			{
+				id: "email_4",
+				batchIndex: 3,
+				status: BULK_EMAIL_ITEM_STATUS.FAILED,
+				updatedAt: old,
+			},
+		];
+
+		expect(
+			selectItemsNeedingPublication({
+				items,
+				messageIdMap: {},
+				batchScheduledAt: null,
+				batchCreatedAt: old,
+				nowMs,
+				includeMissing: true,
+			}),
+		).toHaveLength(0);
+	});
+});
+
+describe("unconfirmed queued accounting", () => {
+	it("counts queued items lacking a confirmed publication", () => {
+		const items = [
+			{
+				id: "a",
+				batchIndex: 0,
+				status: BULK_EMAIL_ITEM_STATUS.QUEUED,
+				updatedAt: null,
+			},
+			{
+				id: "b",
+				batchIndex: 1,
+				status: BULK_EMAIL_ITEM_STATUS.QUEUED,
+				updatedAt: null,
+			},
+			{
+				id: "c",
+				batchIndex: 2,
+				status: BULK_EMAIL_ITEM_STATUS.SENT,
+				updatedAt: null,
+			},
+		];
+
+		expect(countUnconfirmedQueuedItems(items, { a: "msg_a" })).toBe(1);
+		expect(countUnconfirmedQueuedItems(items, {})).toBe(2);
+		expect(countUnconfirmedQueuedItems(items, { a: "m", b: "m" })).toBe(0);
+	});
+
+	it("merges message id maps with newer ids winning", () => {
+		expect(
+			mergeQstashMessageIdMaps({ a: "old", b: "kept" }, { a: "new", c: "add" }),
+		).toEqual({ a: "new", b: "kept", c: "add" });
+	});
+});
+
+describe("limits", () => {
+	it("caps bulk requests at 100 emails", () => {
+		expect(MAX_BULK_EMAILS).toBe(100);
+	});
+
+	it("caps stored attachment payload at 40 MiB per batch", () => {
+		expect(MAX_BULK_STORED_ATTACHMENT_BYTES).toBe(40 * 1024 * 1024);
+	});
+});

--- a/app/api/e2/emails/bulk-helpers.ts
+++ b/app/api/e2/emails/bulk-helpers.ts
@@ -1,0 +1,634 @@
+import {
+	BULK_EMAIL_ITEM_STATUS,
+	EMAIL_BATCH_STATUS,
+	type EmailBatch,
+} from "@/lib/db/schema";
+import { extractEmailAddress } from "@/lib/email-management/agent-email-helper";
+import { formatScheduledDate } from "@/lib/utils/date-parser";
+
+export const MAX_BULK_EMAILS = 100;
+
+/**
+ * Aggregate stored-attachment budget per batch, measured as the serialized
+ * (base64 + JSON) bytes written to sent_emails across ALL item rows,
+ * including per-row duplicates. 40 MiB keeps the worst-case attachment
+ * write per request in the same ballpark as one maximal single-send email
+ * instead of 100x it; bulk is intentionally not the vehicle for large
+ * attachments.
+ */
+export const MAX_BULK_STORED_ATTACHMENT_BYTES = 40 * 1024 * 1024;
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export interface BulkEmailItemInput {
+	from: string;
+	to: string | string[];
+	subject: string;
+	html?: string;
+	text?: string;
+	// cc/bcc are intentionally rejected by validateBulkEmailItem: every bulk
+	// item must map to exactly one recipient so capacity, hourly, and Autumn
+	// accounting (all counted per item) stay truthful.
+	cc?: string | string[];
+	bcc?: string | string[];
+	reply_to?: string | string[];
+	headers?: Record<string, string>;
+	attachments?: Array<{
+		filename: string;
+		content: string;
+		content_type?: string;
+		path?: string;
+	}>;
+	tags?: Array<{ name: string; value: string }>;
+}
+
+export function toAddressArray(value: string | string[] | undefined): string[] {
+	if (!value) return [];
+	return Array.isArray(value) ? value : [value];
+}
+
+/**
+ * Defense in depth for blocklist checks: still surfaces cc/bcc if a caller
+ * smuggles them past schema validation, even though validateBulkEmailItem
+ * rejects any item carrying them.
+ */
+export function collectItemRecipients(item: BulkEmailItemInput): string[] {
+	return [
+		...toAddressArray(item.to),
+		...toAddressArray(item.cc),
+		...toAddressArray(item.bcc),
+	];
+}
+
+export function validateBulkEmailItem(
+	item: BulkEmailItemInput,
+	index: number,
+): string | null {
+	if (!item.from || !item.to || !item.subject) {
+		return `emails[${index}]: from, to, and subject are required`;
+	}
+
+	if (!item.html && !item.text) {
+		return `emails[${index}]: either html or text content must be provided`;
+	}
+
+	// Exactly one recipient per item: each item row is billed and rate
+	// limited as one send, so one item must equal one recipient.
+	const toAddresses = toAddressArray(item.to);
+	if (toAddresses.length !== 1) {
+		return `emails[${index}]: exactly one 'to' recipient is required per bulk email (got ${toAddresses.length})`;
+	}
+
+	if (
+		toAddressArray(item.cc).length > 0 ||
+		toAddressArray(item.bcc).length > 0
+	) {
+		return `emails[${index}]: cc and bcc are not supported for bulk emails; send each recipient as its own email`;
+	}
+
+	const address = extractEmailAddress(toAddresses[0]);
+	if (!EMAIL_REGEX.test(address)) {
+		return `emails[${index}]: invalid email format: ${toAddresses[0]}`;
+	}
+
+	return null;
+}
+
+/**
+ * Total serialized attachment bytes that would be persisted across all item
+ * rows (duplicates counted once per row, exactly as stored). Byte length is
+ * measured on the UTF-8 serialization, matching Postgres text storage.
+ */
+export function totalStoredAttachmentBytes(
+	serializedAttachmentsByItem: Array<string | null>,
+): number {
+	let total = 0;
+	for (const serialized of serializedAttachmentsByItem) {
+		if (serialized) {
+			total += Buffer.byteLength(serialized, "utf8");
+		}
+	}
+	return total;
+}
+
+export interface BulkQueueMessage {
+	type: "batch";
+	emailId: string;
+	userId: string;
+	batchId: string;
+	batchIndex: number;
+}
+
+export function bulkFlowControlKey(userId: string): string {
+	return `bulk-send-${userId}`;
+}
+
+export function bulkDeduplicationId(emailId: string): string {
+	return `bulk_${emailId}`;
+}
+
+/**
+ * QStash delivery retries per message. Combined with
+ * BULK_QSTASH_RETRY_DELAY_EXPRESSION this spreads redelivery of transient
+ * pre-send failures (guard DB blips, billing-service errors, SES throttling)
+ * over roughly 75 minutes before the message is dead-lettered. DLQ'd items
+ * stay 'queued' in the DB and are recovered by publication reconciliation
+ * (idempotent replay or batch status reads), not by a cron.
+ */
+export const BULK_QSTASH_RETRIES = 5;
+
+/**
+ * Delay (milliseconds) between QStash redeliveries: 30s, 150s, 750s, then
+ * capped at 30min. `retried` starts at 0. Total span ≈ 75 minutes, which is
+ * what BULK_PUBLICATION_ABANDONED_MS must comfortably exceed.
+ */
+export const BULK_QSTASH_RETRY_DELAY_EXPRESSION =
+	"min(1800000, 30000 * pow(5, retried))";
+
+const TEN_MINUTES_MS = 10 * 60 * 1000;
+const ONE_HOUR_MS = 60 * 60 * 1000;
+
+/**
+ * QStash keeps deduplication ids for ~90 days, and a duplicate publish is
+ * "accepted but not enqueued". A recovery republish therefore must NOT reuse
+ * the original `bulk_<id>` dedup id: if the original message was already
+ * consumed (delivered or dead-lettered), the republish would be silently
+ * swallowed and the item stuck forever. Versioning by a 10-minute time
+ * bucket makes recovery republishes real messages while still collapsing
+ * rapid repeated reconcile attempts into one message per bucket. Duplicate
+ * deliveries are safe: the worker's CAS claim lets exactly one win.
+ */
+export function bulkRepublishDeduplicationId(
+	emailId: string,
+	nowMs: number,
+): string {
+	return `bulk_${emailId}_r${Math.floor(nowMs / TEN_MINUTES_MS)}`;
+}
+
+/**
+ * Dedup id for the delayed replacement published when a bulk item hits the
+ * hourly send limit. Includes the retry timestamp so consecutive hourly
+ * reschedules of the same item never collide with each other, with the
+ * original message id, or with reconcile republishes.
+ */
+export function bulkHourlyRetryDeduplicationId(
+	emailId: string,
+	retryAtSeconds: number,
+): string {
+	return `bulk_${emailId}_h${retryAtSeconds}`;
+}
+
+const HOURLY_RETRY_BUFFER_MS = 5 * 60 * 1000;
+
+/**
+ * When a bulk item hits the hourly send limit, reschedule it for after the
+ * current rolling hourly window has fully aged out. The window is
+ * [now - 1h, now], so now + 1h guarantees every send counted against the
+ * limit has left the window; the small buffer absorbs clock skew. If the
+ * user has refilled the window by then, the redelivered item re-checks and
+ * reschedules itself again.
+ */
+export function computeHourlyLimitRetryAtSeconds(nowMs: number): number {
+	return Math.ceil((nowMs + ONE_HOUR_MS + HOURLY_RETRY_BUFFER_MS) / 1000);
+}
+
+export interface BulkPublishRequest {
+	url: string;
+	body: BulkQueueMessage;
+	retries: number;
+	retryDelay: string;
+	deduplicationId: string;
+	flowControl: { key: string; parallelism: number };
+	notBefore?: number;
+}
+
+/**
+ * Queue payload carries durable IDs only — item content stays in the DB.
+ * flowControl parallelism 1 serializes worker execution per user so the
+ * hourly guard re-check in the worker observes every prior bulk send.
+ */
+export function buildBulkPublishRequest(params: {
+	webhookUrl: string;
+	emailId: string;
+	userId: string;
+	batchId: string;
+	batchIndex: number;
+	notBefore?: number;
+	/** Override for recovery republishes; defaults to the original per-item id. */
+	deduplicationId?: string;
+}): BulkPublishRequest {
+	return {
+		url: params.webhookUrl,
+		body: {
+			type: "batch",
+			emailId: params.emailId,
+			userId: params.userId,
+			batchId: params.batchId,
+			batchIndex: params.batchIndex,
+		},
+		retries: BULK_QSTASH_RETRIES,
+		retryDelay: BULK_QSTASH_RETRY_DELAY_EXPRESSION,
+		deduplicationId:
+			params.deduplicationId ?? bulkDeduplicationId(params.emailId),
+		flowControl: { key: bulkFlowControlKey(params.userId), parallelism: 1 },
+		...(params.notBefore !== undefined && { notBefore: params.notBefore }),
+	};
+}
+
+export interface BatchCounts {
+	queued: number;
+	processing: number;
+	sent: number;
+	failed: number;
+	cancelled: number;
+}
+
+export function computeBatchCounts(
+	statuses: Array<string | null>,
+): BatchCounts {
+	const counts: BatchCounts = {
+		queued: 0,
+		processing: 0,
+		sent: 0,
+		failed: 0,
+		cancelled: 0,
+	};
+
+	for (const status of statuses) {
+		switch (status) {
+			case BULK_EMAIL_ITEM_STATUS.QUEUED:
+				counts.queued++;
+				break;
+			case BULK_EMAIL_ITEM_STATUS.PROCESSING:
+				counts.processing++;
+				break;
+			case BULK_EMAIL_ITEM_STATUS.SENT:
+				counts.sent++;
+				break;
+			case BULK_EMAIL_ITEM_STATUS.FAILED:
+				counts.failed++;
+				break;
+			case BULK_EMAIL_ITEM_STATUS.CANCELLED:
+				counts.cancelled++;
+				break;
+		}
+	}
+
+	return counts;
+}
+
+export function isBatchComplete(counts: BatchCounts, total: number): boolean {
+	return counts.sent + counts.failed + counts.cancelled >= total;
+}
+
+/**
+ * Honest parent status from the outbox point of view: the batch is only
+ * 'queued' when every still-queued item has a confirmed QStash publication;
+ * any unconfirmed queued item keeps it 'partially_queued' (recoverable via
+ * idempotent replay).
+ */
+export function resolveBatchStatusAfterPublish(
+	unconfirmedQueuedCount: number,
+): string {
+	return unconfirmedQueuedCount === 0
+		? EMAIL_BATCH_STATUS.QUEUED
+		: EMAIL_BATCH_STATUS.PARTIALLY_QUEUED;
+}
+
+/**
+ * Read-time truthful parent status. Item rows are the source of truth; if
+ * every item is terminal but the advisory parent status drifted (lost
+ * counter update, crashed finisher), report completion without mutating.
+ * CANCELLED is sticky — it records a user decision, not item progress.
+ *
+ * `unconfirmedQueuedCount` (queued items with no confirmed QStash
+ * publication) demotes a stored 'queued' to 'partially_queued': after a
+ * creator crash the parent may still say 'queued' even though some items
+ * were never handed to the delivery queue, and a GET intentionally does
+ * not publish them — so it must not present them as fully queued either.
+ */
+export function deriveBatchReadStatus(
+	storedStatus: string,
+	counts: BatchCounts,
+	total: number,
+	unconfirmedQueuedCount = 0,
+): string {
+	if (storedStatus === EMAIL_BATCH_STATUS.CANCELLED) {
+		return storedStatus;
+	}
+	if (total > 0 && isBatchComplete(counts, total)) {
+		return EMAIL_BATCH_STATUS.COMPLETED;
+	}
+	if (
+		unconfirmedQueuedCount > 0 &&
+		storedStatus === EMAIL_BATCH_STATUS.QUEUED
+	) {
+		return EMAIL_BATCH_STATUS.PARTIALLY_QUEUED;
+	}
+	return storedStatus;
+}
+
+/**
+ * True only for SES rejections known to happen before the message is
+ * accepted for delivery (throttling / HTTP 429 / explicit throttling retry
+ * metadata). These are safe to retry because SES has provably not queued
+ * the message. Generic network or timeout failures after calling SES are
+ * deliberately NOT retryable: the send outcome is ambiguous and a retry
+ * could double-send.
+ */
+export function isRetryableSesThrottlingError(error: unknown): boolean {
+	if (!error || typeof error !== "object") {
+		return false;
+	}
+
+	const candidate = error as {
+		name?: unknown;
+		$metadata?: { httpStatusCode?: unknown };
+		$retryable?: { throttling?: unknown };
+	};
+
+	if (
+		typeof candidate.name === "string" &&
+		(candidate.name === "TooManyRequestsException" ||
+			candidate.name === "ThrottlingException")
+	) {
+		return true;
+	}
+
+	if (candidate.$metadata?.httpStatusCode === 429) {
+		return true;
+	}
+
+	if (candidate.$retryable?.throttling === true) {
+		return true;
+	}
+
+	return false;
+}
+
+export function isBulkItemClaimable(status: string | null): boolean {
+	return status === BULK_EMAIL_ITEM_STATUS.QUEUED;
+}
+
+export function isBulkItemCancellable(status: string | null): boolean {
+	return status === BULK_EMAIL_ITEM_STATUS.QUEUED;
+}
+
+export function attachmentsCacheKey(
+	attachments: BulkEmailItemInput["attachments"],
+): string {
+	return JSON.stringify(attachments ?? []);
+}
+
+export interface BulkAcceptedResponseBody {
+	id: string;
+	status: string;
+	total: number;
+	scheduled_at?: string;
+	timezone?: string;
+	data: Array<{ id: string; index: number }>;
+}
+
+/**
+ * Deterministic acceptance/replay shape: same batch produces the same body
+ * (modulo lifecycle status) so Idempotency-Key retries are safe.
+ */
+export function buildBulkAcceptedResponse(
+	batch: Pick<
+		EmailBatch,
+		"id" | "status" | "total" | "scheduledAt" | "timezone"
+	>,
+	items: Array<{ id: string; batchIndex: number | null }>,
+): BulkAcceptedResponseBody {
+	const sorted = [...items].sort(
+		(a, b) => (a.batchIndex ?? 0) - (b.batchIndex ?? 0),
+	);
+
+	return {
+		id: batch.id,
+		status: batch.status,
+		total: batch.total,
+		...(batch.scheduledAt && {
+			scheduled_at: formatScheduledDate(batch.scheduledAt),
+			timezone: batch.timezone || "UTC",
+		}),
+		data: sorted.map((item) => ({
+			id: item.id,
+			index: item.batchIndex ?? 0,
+		})),
+	};
+}
+
+/**
+ * How long a batch may sit with fewer item rows than `total` and no
+ * publication before it is treated as a dead partial creation, letting an
+ * idempotent retry clean up the unsent rows and recreate instead of
+ * returning 409 forever. Creation inserts item rows in seconds; the
+ * threshold is deliberately far beyond the maximum serverless function
+ * lifetime (15 min on Vercel) so a cleanup can never race a creator that
+ * is merely slow — by 45 minutes the creating invocation is provably dead.
+ */
+export const BULK_CREATION_STALE_MS = 45 * 60 * 1000;
+
+/**
+ * True when a partially-created batch (items < total) provably never
+ * published anything and is old enough that its creator is dead. Only such
+ * batches are safe to clean up: no QStash message ids were ever recorded,
+ * so no worker can be racing us on these rows.
+ */
+export function isStaleUnpublishedCreation(params: {
+	batchStatus: string;
+	batchCreatedAt: Date | null;
+	batchTotal: number;
+	itemCount: number;
+	messageIdMap: Record<string, string>;
+	nowMs: number;
+}): boolean {
+	if (params.itemCount >= params.batchTotal) return false;
+	if (params.batchStatus === EMAIL_BATCH_STATUS.CANCELLED) return false;
+	if (Object.keys(params.messageIdMap).length > 0) return false;
+	if (!params.batchCreatedAt) return true;
+	return (
+		params.nowMs - params.batchCreatedAt.getTime() > BULK_CREATION_STALE_MS
+	);
+}
+
+/**
+ * How long past its due time a queued item with a confirmed publication may
+ * go untouched before reconciliation treats the message as lost (delivery
+ * retries exhausted / DLQ'd) and republishes it. Must comfortably exceed
+ * the ~75 minute QStash retry span (BULK_QSTASH_RETRY_DELAY_EXPRESSION) and
+ * the ~65 minute hourly-limit reschedule delay; every worker touch (claim /
+ * requeue) bumps the item's updatedAt, restarting this clock.
+ */
+export const BULK_PUBLICATION_ABANDONED_MS = 2 * 60 * 60 * 1000;
+
+export interface BulkPublicationItemState {
+	id: string;
+	batchIndex: number | null;
+	status: string | null;
+	updatedAt: Date | null;
+}
+
+export interface BulkItemToPublish {
+	id: string;
+	batchIndex: number;
+	deduplicationId: string;
+	reason: "missing" | "abandoned";
+}
+
+/**
+ * Pure outbox scan: decides which still-queued items need a (re)publish.
+ *
+ * - "missing": queued with no recorded message id — publication was never
+ *   confirmed (crash between item insert and QStash confirmation, or a
+ *   failed publish call). Only selected when `includeMissing` is true,
+ *   i.e. on an explicit idempotent replay: the client was never told these
+ *   were queued, so a background status read must not start delivering
+ *   them behind the client's back.
+ * - "abandoned": queued with a recorded message id, but long past due and
+ *   untouched — QStash exhausted delivery retries (DLQ) or the message was
+ *   otherwise lost. These were accepted as queued, so both replays and
+ *   status reads recover them.
+ *
+ * Cancelled/processing/terminal items are never selected, and items in a
+ * future-scheduled batch are never treated as abandoned (their messages
+ * are legitimately parked until notBefore). Republishes always use
+ * versioned dedup ids; duplicates are neutralized by the worker's CAS.
+ */
+export function selectItemsNeedingPublication(params: {
+	items: BulkPublicationItemState[];
+	messageIdMap: Record<string, string>;
+	batchScheduledAt: Date | null;
+	batchCreatedAt: Date | null;
+	nowMs: number;
+	includeMissing: boolean;
+}): BulkItemToPublish[] {
+	const {
+		items,
+		messageIdMap,
+		batchScheduledAt,
+		batchCreatedAt,
+		nowMs,
+		includeMissing,
+	} = params;
+
+	const dueAtMs = Math.max(
+		batchScheduledAt?.getTime() ?? 0,
+		batchCreatedAt?.getTime() ?? 0,
+	);
+
+	const toPublish: BulkItemToPublish[] = [];
+	for (const item of items) {
+		if (item.status !== BULK_EMAIL_ITEM_STATUS.QUEUED) continue;
+
+		const lastTouchedMs = item.updatedAt?.getTime() ?? dueAtMs;
+
+		if (!messageIdMap[item.id]) {
+			if (includeMissing) {
+				toPublish.push({
+					id: item.id,
+					batchIndex: item.batchIndex ?? 0,
+					deduplicationId: bulkRepublishDeduplicationId(item.id, nowMs),
+					reason: "missing",
+				});
+			}
+			continue;
+		}
+
+		const overdue =
+			nowMs - dueAtMs > BULK_PUBLICATION_ABANDONED_MS &&
+			nowMs - lastTouchedMs > BULK_PUBLICATION_ABANDONED_MS;
+		if (overdue) {
+			toPublish.push({
+				id: item.id,
+				batchIndex: item.batchIndex ?? 0,
+				deduplicationId: bulkRepublishDeduplicationId(item.id, nowMs),
+				reason: "abandoned",
+			});
+		}
+	}
+
+	return toPublish;
+}
+
+/**
+ * How long a claimed ('processing') item may go untouched before status
+ * reads surface it as stale. Deliberately conservative: 45 minutes is 3x
+ * the maximum serverless function lifetime (15 min on Vercel), same
+ * reasoning as BULK_CREATION_STALE_MS, so a legitimately in-flight send
+ * can never be flagged. Stale items are surfaced for ops visibility only
+ * — they are intentionally NOT auto-requeued, because a claim that died
+ * after handing the message to SES must never be retried (double send).
+ */
+export const BULK_PROCESSING_STALE_MS = 45 * 60 * 1000;
+
+/**
+ * Items stuck in 'processing' well past any legitimate worker lifetime
+ * (crashed mid-send, or sent but the success write failed). Items without
+ * an updatedAt are skipped rather than guessed at: every claim stamps
+ * updatedAt, so a missing value says nothing about staleness.
+ */
+export function countStaleProcessingItems(
+	items: Array<Pick<BulkPublicationItemState, "status" | "updatedAt">>,
+	nowMs: number,
+): number {
+	let stale = 0;
+	for (const item of items) {
+		if (item.status !== BULK_EMAIL_ITEM_STATUS.PROCESSING) continue;
+		if (!item.updatedAt) continue;
+		if (nowMs - item.updatedAt.getTime() > BULK_PROCESSING_STALE_MS) {
+			stale++;
+		}
+	}
+	return stale;
+}
+
+/**
+ * Queued items whose publication has never been confirmed (no recorded
+ * QStash message id). While this is non-zero the batch must not be
+ * presented as fully queued.
+ */
+export function countUnconfirmedQueuedItems(
+	items: BulkPublicationItemState[],
+	messageIdMap: Record<string, string>,
+): number {
+	let unconfirmed = 0;
+	for (const item of items) {
+		if (
+			item.status === BULK_EMAIL_ITEM_STATUS.QUEUED &&
+			!messageIdMap[item.id]
+		) {
+			unconfirmed++;
+		}
+	}
+	return unconfirmed;
+}
+
+export function mergeQstashMessageIdMaps(
+	base: Record<string, string>,
+	incoming: Record<string, string>,
+): Record<string, string> {
+	return { ...base, ...incoming };
+}
+
+export function parseQstashMessageIdMap(
+	raw: string | null,
+): Record<string, string> {
+	if (!raw) return {};
+	try {
+		const parsed: unknown = JSON.parse(raw);
+		if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+			const result: Record<string, string> = {};
+			for (const [key, value] of Object.entries(parsed)) {
+				if (typeof value === "string") {
+					result[key] = value;
+				}
+			}
+			return result;
+		}
+	} catch {
+		return {};
+	}
+	return {};
+}

--- a/app/api/e2/emails/bulk-queue.ts
+++ b/app/api/e2/emails/bulk-queue.ts
@@ -1,0 +1,367 @@
+import { Client as QStashClient } from "@upstash/qstash";
+import { and, eq, inArray, sql } from "drizzle-orm";
+import { db } from "@/lib/db";
+import {
+	BULK_EMAIL_ITEM_STATUS,
+	EMAIL_BATCH_STATUS,
+	type EmailBatch,
+	emailBatches,
+	sentEmails,
+} from "@/lib/db/schema";
+import {
+	type BulkItemToPublish,
+	type BulkPublicationItemState,
+	buildBulkPublishRequest,
+	countUnconfirmedQueuedItems,
+	mergeQstashMessageIdMaps,
+	parseQstashMessageIdMap,
+	resolveBatchStatusAfterPublish,
+	selectItemsNeedingPublication,
+} from "./bulk-helpers";
+
+/**
+ * Shared QStash publication + reconciliation for bulk batches.
+ *
+ * Publication is intentionally not transactional with item creation, so this
+ * module implements the recovery half of the outbox pattern: item rows are
+ * the durable source of truth, `email_batches.qstash_message_ids` records
+ * which items have a confirmed publication, and reconciliation republishes
+ * still-queued items whose message was never confirmed or was lost. The
+ * worker's compare-and-swap claim makes duplicate deliveries safe, so
+ * reconciliation only ever risks wasted deliveries, never double sends.
+ */
+
+export interface BulkQueueConfig {
+	webhookUrl: string;
+	qstashToken: string;
+}
+
+export function getBulkQueueConfig(): BulkQueueConfig | null {
+	const appUrl = process.env.NEXT_PUBLIC_APP_URL;
+	const qstashToken = process.env.QSTASH_TOKEN;
+	if (!appUrl || !qstashToken) {
+		return null;
+	}
+	return {
+		webhookUrl: `${appUrl}/api/webhooks/send-email`,
+		qstashToken,
+	};
+}
+
+export interface BulkPublishEntry {
+	id: string;
+	batchIndex: number;
+	/** Optional dedup override for recovery republishes. */
+	deduplicationId?: string;
+}
+
+export interface BulkPublishOutcome {
+	/** Item id -> QStash message id for every confirmed publication. */
+	messageIdMap: Record<string, string>;
+	publishedCount: number;
+	failedCount: number;
+	errorMessage: string | null;
+}
+
+/**
+ * Publishes queue messages for the given items. Never throws: failures are
+ * reported in the outcome so callers can persist partial progress before
+ * deciding how to answer.
+ */
+export async function publishBulkQueueMessages(params: {
+	config: BulkQueueConfig;
+	userId: string;
+	batchId: string;
+	entries: BulkPublishEntry[];
+	notBefore?: number;
+}): Promise<BulkPublishOutcome> {
+	const { config, userId, batchId, entries, notBefore } = params;
+
+	if (entries.length === 0) {
+		return {
+			messageIdMap: {},
+			publishedCount: 0,
+			failedCount: 0,
+			errorMessage: null,
+		};
+	}
+
+	const requests = entries.map((entry) =>
+		buildBulkPublishRequest({
+			webhookUrl: config.webhookUrl,
+			emailId: entry.id,
+			userId,
+			batchId,
+			batchIndex: entry.batchIndex,
+			notBefore,
+			deduplicationId: entry.deduplicationId,
+		}),
+	);
+
+	const messageIdMap: Record<string, string> = {};
+	let errorMessage: string | null = null;
+
+	try {
+		const qstashClient = new QStashClient({ token: config.qstashToken });
+		const responses = await qstashClient.batchJSON(requests);
+
+		responses.forEach((response, index) => {
+			const messageId = response?.messageId;
+			if (messageId) {
+				messageIdMap[requests[index].body.emailId] = messageId;
+			}
+		});
+	} catch (qstashError) {
+		console.error("❌ Failed to publish bulk queue messages:", qstashError);
+		errorMessage =
+			qstashError instanceof Error
+				? qstashError.message
+				: "Failed to enqueue batch";
+	}
+
+	const publishedCount = Object.keys(messageIdMap).length;
+	return {
+		messageIdMap,
+		publishedCount,
+		failedCount: entries.length - publishedCount,
+		errorMessage,
+	};
+}
+
+/**
+ * Merges newly confirmed message ids into the parent's JSON map without
+ * clobbering concurrent writers. The merge happens inside Postgres in a
+ * single statement (`jsonb ||`), so a creator, a replay, and a status-read
+ * reconciler can all record ids concurrently; last-writer-wins only applies
+ * per key, which is fine because a given item id maps to equivalent ids.
+ * Falls back to read-merge-write if the stored value is not valid JSON.
+ */
+export async function mergeBatchQstashMessageIds(
+	batchId: string,
+	newIds: Record<string, string>,
+): Promise<void> {
+	if (Object.keys(newIds).length === 0) return;
+
+	const serialized = JSON.stringify(newIds);
+	try {
+		await db
+			.update(emailBatches)
+			.set({
+				qstashMessageIds: sql`(COALESCE(${emailBatches.qstashMessageIds}, '{}')::jsonb || ${serialized}::jsonb)::text`,
+				updatedAt: new Date(),
+			})
+			.where(eq(emailBatches.id, batchId));
+	} catch (mergeError) {
+		console.error(
+			"⚠️ Atomic message-id merge failed, falling back to read-merge-write:",
+			mergeError,
+		);
+		const [row] = await db
+			.select({ qstashMessageIds: emailBatches.qstashMessageIds })
+			.from(emailBatches)
+			.where(eq(emailBatches.id, batchId))
+			.limit(1);
+		const merged = mergeQstashMessageIdMaps(
+			parseQstashMessageIdMap(row?.qstashMessageIds ?? null),
+			newIds,
+		);
+		await db
+			.update(emailBatches)
+			.set({
+				qstashMessageIds: JSON.stringify(merged),
+				updatedAt: new Date(),
+			})
+			.where(eq(emailBatches.id, batchId));
+	}
+}
+
+/**
+ * Records the publication state on the parent without ever resurrecting a
+ * terminal batch: only 'queued'/'partially_queued' parents are touched, so
+ * a concurrent cancel (CANCELLED) or the last finishing worker (COMPLETED)
+ * always wins over a slower creator or reconciler.
+ */
+export async function applyBatchPublicationState(params: {
+	batchId: string;
+	unconfirmedQueuedCount: number;
+	errorMessage: string | null;
+}): Promise<void> {
+	const fullyPublished = params.unconfirmedQueuedCount === 0;
+	await db
+		.update(emailBatches)
+		.set({
+			status: resolveBatchStatusAfterPublish(params.unconfirmedQueuedCount),
+			lastError: fullyPublished ? null : params.errorMessage,
+			updatedAt: new Date(),
+		})
+		.where(
+			and(
+				eq(emailBatches.id, params.batchId),
+				inArray(emailBatches.status, [
+					EMAIL_BATCH_STATUS.QUEUED,
+					EMAIL_BATCH_STATUS.PARTIALLY_QUEUED,
+				]),
+			),
+		);
+}
+
+export interface BulkReconcileResult {
+	/** Items this pass tried to (re)publish. */
+	attempted: BulkItemToPublish[];
+	publishedCount: number;
+	/** Queued items still lacking a confirmed publication after this pass. */
+	unconfirmedQueuedCount: number;
+	errorMessage: string | null;
+}
+
+/**
+ * Outbox reconciliation for one batch: republishes still-queued items whose
+ * publication was never confirmed ("missing") or whose message is provably
+ * overdue ("abandoned"), then records the honest publication state on the
+ * parent. Scheduled batches keep their original notBefore. Cancelled
+ * batches are never touched.
+ */
+export async function reconcileBatchPublication(params: {
+	config: BulkQueueConfig;
+	batch: Pick<
+		EmailBatch,
+		| "id"
+		| "userId"
+		| "status"
+		| "scheduledAt"
+		| "createdAt"
+		| "qstashMessageIds"
+	>;
+	items: BulkPublicationItemState[];
+	/**
+	 * true on explicit idempotent replays (republish never-confirmed items);
+	 * false on status reads (only recover abandoned confirmed publications —
+	 * a read must not start delivering emails the client was told were not
+	 * queued).
+	 */
+	includeMissing: boolean;
+}): Promise<BulkReconcileResult> {
+	const { config, batch, items, includeMissing } = params;
+	const nowMs = Date.now();
+	const messageIdMap = parseQstashMessageIdMap(batch.qstashMessageIds);
+
+	if (batch.status === EMAIL_BATCH_STATUS.CANCELLED) {
+		return {
+			attempted: [],
+			publishedCount: 0,
+			unconfirmedQueuedCount: countUnconfirmedQueuedItems(items, messageIdMap),
+			errorMessage: null,
+		};
+	}
+
+	const toPublish = selectItemsNeedingPublication({
+		items,
+		messageIdMap,
+		batchScheduledAt: batch.scheduledAt,
+		batchCreatedAt: batch.createdAt,
+		nowMs,
+		includeMissing,
+	});
+
+	if (toPublish.length === 0) {
+		const unconfirmedQueuedCount = countUnconfirmedQueuedItems(
+			items,
+			messageIdMap,
+		);
+		// Repair advisory drift: every queued item has a confirmed
+		// publication but the parent still says partially_queued (e.g. the
+		// creator crashed between recording ids and updating the status).
+		if (
+			unconfirmedQueuedCount === 0 &&
+			batch.status === EMAIL_BATCH_STATUS.PARTIALLY_QUEUED
+		) {
+			await applyBatchPublicationState({
+				batchId: batch.id,
+				unconfirmedQueuedCount: 0,
+				errorMessage: null,
+			});
+		}
+		return {
+			attempted: [],
+			publishedCount: 0,
+			unconfirmedQueuedCount,
+			errorMessage: null,
+		};
+	}
+
+	// Preserve the batch-level schedule on republish: a replay of a
+	// scheduled batch must not deliver early.
+	const notBefore =
+		batch.scheduledAt && batch.scheduledAt.getTime() > nowMs
+			? Math.floor(batch.scheduledAt.getTime() / 1000)
+			: undefined;
+
+	const outcome = await publishBulkQueueMessages({
+		config,
+		userId: batch.userId,
+		batchId: batch.id,
+		entries: toPublish,
+		notBefore,
+	});
+
+	if (outcome.publishedCount > 0) {
+		await mergeBatchQstashMessageIds(batch.id, outcome.messageIdMap);
+
+		// Bump updatedAt on the republished (still-queued) rows so repeated
+		// reconciliation passes back off instead of republishing every time.
+		try {
+			await db
+				.update(sentEmails)
+				.set({ updatedAt: new Date() })
+				.where(
+					and(
+						inArray(
+							sentEmails.id,
+							toPublish
+								.filter((item) => outcome.messageIdMap[item.id])
+								.map((item) => item.id),
+						),
+						eq(sentEmails.userId, batch.userId),
+						eq(sentEmails.status, BULK_EMAIL_ITEM_STATUS.QUEUED),
+					),
+				);
+		} catch (bumpError) {
+			console.error(
+				"⚠️ Failed to bump reconciled bulk items (non-fatal):",
+				bumpError,
+			);
+		}
+	}
+
+	const mergedMap = mergeQstashMessageIdMaps(
+		messageIdMap,
+		outcome.messageIdMap,
+	);
+	const unconfirmedQueuedCount = countUnconfirmedQueuedItems(items, mergedMap);
+
+	const errorMessage =
+		unconfirmedQueuedCount > 0
+			? (outcome.errorMessage ??
+				`${unconfirmedQueuedCount} queued email(s) awaiting publication`)
+			: null;
+
+	await applyBatchPublicationState({
+		batchId: batch.id,
+		unconfirmedQueuedCount,
+		errorMessage,
+	});
+
+	console.log("🔁 Bulk batch publication reconciled:", {
+		batchId: batch.id,
+		attempted: toPublish.length,
+		published: outcome.publishedCount,
+		unconfirmedQueuedCount,
+	});
+
+	return {
+		attempted: toPublish,
+		publishedCount: outcome.publishedCount,
+		unconfirmedQueuedCount,
+		errorMessage,
+	};
+}

--- a/app/api/e2/emails/bulk-send.ts
+++ b/app/api/e2/emails/bulk-send.ts
@@ -1,0 +1,777 @@
+import { Autumn as autumn } from "autumn-js";
+import { and, eq } from "drizzle-orm";
+import { Elysia, t } from "elysia";
+import { nanoid } from "nanoid";
+import { AttachmentSchema, TagSchema } from "@/app/api/e2/emails/send";
+import { db } from "@/lib/db";
+import {
+	BULK_EMAIL_ITEM_STATUS,
+	EMAIL_BATCH_STATUS,
+	type EmailBatch,
+	emailBatches,
+	type NewSentEmail,
+	sentEmails,
+} from "@/lib/db/schema";
+import {
+	canUserSendFromEmail,
+	extractDomain,
+	extractEmailAddress,
+} from "@/lib/email-management/agent-email-helper";
+import { checkRecipientsAgainstBlocklist } from "@/lib/email-management/email-blocking";
+import {
+	enforceOutboundSendGuard,
+	getHourlySendCapacity,
+	type OutboundSendGuardResult,
+} from "@/lib/email-management/outbound-send-guard";
+import {
+	type ParsedScheduleDate,
+	parseScheduledAt,
+	validateScheduledDate,
+} from "@/lib/utils/date-parser";
+import {
+	attachmentsToStorageFormat,
+	type ProcessedAttachment,
+	processAttachments,
+} from "../helper/attachment-processor";
+import {
+	authenticateEmailSend,
+	senderPolicyAllowsAddress,
+} from "../lib/send-auth";
+import {
+	attachmentsCacheKey,
+	BULK_CREATION_STALE_MS,
+	type BulkAcceptedResponseBody,
+	type BulkEmailItemInput,
+	buildBulkAcceptedResponse,
+	collectItemRecipients,
+	isBulkItemClaimable,
+	isStaleUnpublishedCreation,
+	MAX_BULK_EMAILS,
+	MAX_BULK_STORED_ATTACHMENT_BYTES,
+	parseQstashMessageIdMap,
+	toAddressArray,
+	totalStoredAttachmentBytes,
+	validateBulkEmailItem,
+} from "./bulk-helpers";
+import {
+	applyBatchPublicationState,
+	type BulkQueueConfig,
+	getBulkQueueConfig,
+	mergeBatchQstashMessageIds,
+	publishBulkQueueMessages,
+	reconcileBatchPublication,
+} from "./bulk-queue";
+
+const BulkEmailItemSchema = t.Object({
+	from: t.String({ description: "Sender email address" }),
+	to: t.Union([t.String(), t.Array(t.String(), { minItems: 1, maxItems: 1 })], {
+		description:
+			"Recipient email address (exactly one per email; each item is billed and rate limited as one recipient)",
+	}),
+	subject: t.String({ description: "Email subject" }),
+	html: t.Optional(t.String({ description: "HTML content of the email" })),
+	text: t.Optional(
+		t.String({ description: "Plain text content of the email" }),
+	),
+	// cc/bcc stay in the schema so requests carrying them are rejected with a
+	// clear 400 by validateBulkEmailItem instead of being silently stripped.
+	cc: t.Optional(
+		t.Union([t.String(), t.Array(t.String())], {
+			description: "Not supported for bulk emails (rejected)",
+		}),
+	),
+	bcc: t.Optional(
+		t.Union([t.String(), t.Array(t.String())], {
+			description: "Not supported for bulk emails (rejected)",
+		}),
+	),
+	reply_to: t.Optional(t.Union([t.String(), t.Array(t.String())])),
+	headers: t.Optional(t.Record(t.String(), t.String())),
+	attachments: t.Optional(t.Array(AttachmentSchema)),
+	tags: t.Optional(t.Array(TagSchema)),
+});
+
+const SendBulkEmailBodySchema = t.Object({
+	emails: t.Array(BulkEmailItemSchema, {
+		minItems: 1,
+		maxItems: MAX_BULK_EMAILS,
+		description: `Up to ${MAX_BULK_EMAILS} emails per batch`,
+	}),
+	scheduled_at: t.Optional(
+		t.String({
+			description:
+				"Batch-level schedule (ISO 8601 or natural language). Applies to every email in the batch.",
+		}),
+	),
+	timezone: t.Optional(
+		t.String({ description: "Timezone for natural language parsing" }),
+	),
+});
+
+const BulkAcceptedResponse = t.Object({
+	id: t.String(),
+	status: t.String(),
+	total: t.Integer(),
+	scheduled_at: t.Optional(t.String()),
+	timezone: t.Optional(t.String()),
+	data: t.Array(t.Object({ id: t.String(), index: t.Integer() })),
+});
+
+const ErrorResponse = t.Object({
+	error: t.String(),
+});
+
+const CREATION_IN_PROGRESS_ERROR = `A batch for this Idempotency-Key is still being created. Retry the same request shortly. If the creating request crashed before finishing, a retry with the same key recovers automatically after ${BULK_CREATION_STALE_MS / 60_000} minutes.`;
+
+type ExistingBatchOutcome =
+	| {
+			kind: "response";
+			status: 202 | 409 | 503;
+			body: BulkAcceptedResponseBody | { error: string };
+	  }
+	| { kind: "recreate" };
+
+/**
+ * Answers an idempotent replay for an existing batch.
+ *
+ * This is where the outbox recovery happens: a 202 is only returned once
+ * every still-queued item has a confirmed QStash publication (missing ones
+ * are republished right here, preserving the batch's notBefore) or the
+ * publication gap is honestly represented (partially_queued + lastError).
+ * A batch that died mid-creation (items < total) yields a retryable 409
+ * while fresh, and is cleaned up and recreated once it is provably stale
+ * and nothing was ever published.
+ */
+async function respondForExistingBatch(
+	batch: EmailBatch,
+	config: BulkQueueConfig,
+	options: { allowRecreate: boolean },
+): Promise<ExistingBatchOutcome> {
+	const items = await db
+		.select({
+			id: sentEmails.id,
+			batchIndex: sentEmails.batchIndex,
+			status: sentEmails.status,
+			updatedAt: sentEmails.updatedAt,
+		})
+		.from(sentEmails)
+		.where(
+			and(
+				eq(sentEmails.batchId, batch.id),
+				eq(sentEmails.userId, batch.userId),
+			),
+		);
+
+	// CANCELLED is a user decision and sticky: replay it verbatim, never
+	// republish, even if creation was interrupted.
+	if (batch.status === EMAIL_BATCH_STATUS.CANCELLED) {
+		return {
+			kind: "response",
+			status: 202,
+			body: buildBulkAcceptedResponse(batch, items),
+		};
+	}
+
+	if (items.length < batch.total) {
+		const messageIdMap = parseQstashMessageIdMap(batch.qstashMessageIds);
+		const stale = isStaleUnpublishedCreation({
+			batchStatus: batch.status,
+			batchCreatedAt: batch.createdAt,
+			batchTotal: batch.total,
+			itemCount: items.length,
+			messageIdMap,
+			nowMs: Date.now(),
+		});
+
+		if (stale && options.allowRecreate) {
+			console.log(
+				"🧹 Cleaning up stale partially-created batch for recreation:",
+				batch.id,
+			);
+			// Nothing was ever published for this batch, so no worker can be
+			// racing us; still, only remove rows that are safe to remove.
+			await db
+				.delete(sentEmails)
+				.where(
+					and(
+						eq(sentEmails.batchId, batch.id),
+						eq(sentEmails.userId, batch.userId),
+						eq(sentEmails.status, BULK_EMAIL_ITEM_STATUS.QUEUED),
+					),
+				);
+			const [remaining] = await db
+				.select({ id: sentEmails.id })
+				.from(sentEmails)
+				.where(eq(sentEmails.batchId, batch.id))
+				.limit(1);
+			if (remaining) {
+				console.error(
+					"❌ Stale batch cleanup left non-queued rows behind, refusing to recreate:",
+					batch.id,
+				);
+				return {
+					kind: "response",
+					status: 409,
+					body: { error: CREATION_IN_PROGRESS_ERROR },
+				};
+			}
+			await db.delete(emailBatches).where(eq(emailBatches.id, batch.id));
+			return { kind: "recreate" };
+		}
+
+		return {
+			kind: "response",
+			status: 409,
+			body: { error: CREATION_IN_PROGRESS_ERROR },
+		};
+	}
+
+	// Batch is fully created: republish any still-queued item whose
+	// publication was never confirmed or whose message was abandoned.
+	const reconcile = await reconcileBatchPublication({
+		config,
+		batch,
+		items,
+		includeMissing: true,
+	});
+
+	if (
+		reconcile.unconfirmedQueuedCount > 0 &&
+		reconcile.publishedCount === 0 &&
+		reconcile.attempted.length > 0
+	) {
+		return {
+			kind: "response",
+			status: 503,
+			body: {
+				error: `Batch ${batch.id} is stored durably but ${reconcile.unconfirmedQueuedCount} queued email(s) could not be published for delivery${reconcile.errorMessage ? ` (${reconcile.errorMessage})` : ""}. Retry this request with the same Idempotency-Key to publish the remainder, or cancel the batch.`,
+			},
+		};
+	}
+
+	// Re-read the parent so the replay body reflects the reconciled status
+	// (and any concurrent completion/cancellation).
+	const [freshBatch] = await db
+		.select()
+		.from(emailBatches)
+		.where(eq(emailBatches.id, batch.id))
+		.limit(1);
+
+	return {
+		kind: "response",
+		status: 202,
+		body: buildBulkAcceptedResponse(freshBatch ?? batch, items),
+	};
+}
+
+export const sendBulkEmails = new Elysia().post(
+	"/emails/bulk",
+	async ({ request, body, set }) => {
+		console.log("📧 POST /api/e2/emails/bulk - Starting request");
+
+		const { userId, senderPolicy } = await authenticateEmailSend(request, set);
+		console.log("✅ Authentication successful for userId:", userId);
+
+		const idempotencyKey = request.headers.get("Idempotency-Key");
+		if (idempotencyKey && idempotencyKey.length > 256) {
+			set.status = 400;
+			return { error: "Idempotency-Key must be 256 characters or fewer" };
+		}
+
+		// Fail fast on missing configuration before any persistence or replay:
+		// creation would produce a batch no worker ever picks up, and replays
+		// could not republish missing publications.
+		const queueConfig = getBulkQueueConfig();
+		if (!queueConfig) {
+			console.error("❌ Bulk send misconfigured:", {
+				hasAppUrl: Boolean(process.env.NEXT_PUBLIC_APP_URL),
+				hasQstashToken: Boolean(process.env.QSTASH_TOKEN),
+			});
+			set.status = 500;
+			return { error: "Email queueing is not configured on this server" };
+		}
+
+		if (idempotencyKey) {
+			const [existingBatch] = await db
+				.select()
+				.from(emailBatches)
+				.where(
+					and(
+						eq(emailBatches.userId, userId),
+						eq(emailBatches.idempotencyKey, idempotencyKey),
+					),
+				)
+				.limit(1);
+
+			if (existingBatch) {
+				const outcome = await respondForExistingBatch(
+					existingBatch,
+					queueConfig,
+					{ allowRecreate: true },
+				);
+				if (outcome.kind === "response") {
+					console.log(
+						"♻️ Idempotent bulk request - replaying existing batch:",
+						existingBatch.id,
+						"status:",
+						outcome.status,
+					);
+					set.status = outcome.status;
+					return outcome.body;
+				}
+				// Stale dead creation was cleaned up: fall through and create
+				// the batch again under the same key.
+			}
+		}
+
+		const items = body.emails as BulkEmailItemInput[];
+
+		let parsedDate: ParsedScheduleDate | null = null;
+		if (body.scheduled_at) {
+			parsedDate = parseScheduledAt(body.scheduled_at, body.timezone || "UTC");
+			if (!parsedDate.isValid) {
+				set.status = 400;
+				return { error: parsedDate.error || "Invalid scheduled date" };
+			}
+
+			const dateValidation = validateScheduledDate(parsedDate.date);
+			if (!dateValidation.isValid) {
+				set.status = 400;
+				return { error: dateValidation.error || "Invalid scheduled date" };
+			}
+		}
+
+		// A batch scheduled for the future is not competing for the CURRENT
+		// rolling hourly window, so acceptance must not reject it on that
+		// window: the worker re-checks the guard (deny_only) per item at
+		// execution time and reschedules overflow past the window. All other
+		// guard denials (ban, tenant, domain, sender address) and the Autumn
+		// plan-capacity check below still apply at acceptance.
+		const isFutureSchedule = Boolean(
+			parsedDate && parsedDate.date.getTime() > Date.now(),
+		);
+
+		for (let index = 0; index < items.length; index++) {
+			const validationError = validateBulkEmailItem(items[index], index);
+			if (validationError) {
+				set.status = 400;
+				return { error: validationError };
+			}
+
+			if (senderPolicy) {
+				const fromAddress = extractEmailAddress(items[index].from);
+				if (!senderPolicyAllowsAddress(senderPolicy, fromAddress)) {
+					set.status = 403;
+					return {
+						error: `emails[${index}]: this credential cannot send from that address`,
+					};
+				}
+			}
+		}
+
+		const guardResults = new Map<string, OutboundSendGuardResult>();
+		for (let index = 0; index < items.length; index++) {
+			const item = items[index];
+			const fromAddress = extractEmailAddress(item.from);
+			const fromDomain = extractDomain(item.from);
+			const { isAgentEmail } = canUserSendFromEmail(item.from);
+			const guardKey = `${fromAddress}|${fromDomain}|${isAgentEmail}`;
+
+			let guard = guardResults.get(guardKey);
+			if (!guard) {
+				// deny_only: rejecting an over-capacity bulk submission is
+				// plain backpressure (the weighted capacity check below
+				// enforces the hourly window). Pausing the tenant here would
+				// permanently fail every already-queued batch item as
+				// tenant_inactive. Single sends keep the pause behavior.
+				// Future-scheduled batches use "ignore": the current window is
+				// irrelevant to them and the worker enforces it at execution.
+				guard = await enforceOutboundSendGuard({
+					userId,
+					fromAddress,
+					fromDomain,
+					isAgentEmail,
+					hourlyLimitAction: isFutureSchedule ? "ignore" : "deny_only",
+				});
+				guardResults.set(guardKey, guard);
+			}
+
+			if (!guard.allowed) {
+				console.log("🚫 Bulk outbound send blocked:", {
+					userId,
+					fromAddress,
+					fromDomain,
+					reasonCode: guard.reasonCode,
+				});
+				set.status = guard.statusCode;
+				return {
+					error: `emails[${index}]: ${guard.error || "Email send blocked"}`,
+				};
+			}
+		}
+
+		const allRecipients = items.flatMap(collectItemRecipients);
+		const blocklistCheck = await checkRecipientsAgainstBlocklist(allRecipients);
+		if (blocklistCheck.hasBlockedRecipients) {
+			set.status = 400;
+			return {
+				error: `Cannot send to blocked recipient(s): ${blocklistCheck.blockedAddresses.join(", ")}. These addresses previously bounced.`,
+			};
+		}
+
+		// Weighted acceptance for immediate batches: a bulk request must fit
+		// in the remaining hourly window up front because the guard alone
+		// only rejects per-send. One item = one recipient (enforced above),
+		// so items.length is the true recipient count. Future-scheduled
+		// batches skip this — the window that matters is the one at delivery
+		// time, which the worker enforces per item (and reschedules past).
+		if (!isFutureSchedule) {
+			const capacity = await getHourlySendCapacity(userId);
+			if (capacity.remaining !== null && items.length > capacity.remaining) {
+				set.status = 429;
+				return {
+					error: `Bulk request of ${items.length} emails exceeds remaining hourly capacity (${capacity.remaining} of ${capacity.limit}).`,
+				};
+			}
+		}
+
+		const { data: emailCheck, error: emailCheckError } = await autumn.check({
+			customer_id: userId,
+			feature_id: "emails_sent",
+			required_balance: items.length,
+		});
+
+		if (emailCheckError) {
+			console.error("❌ Autumn bulk email check error:", emailCheckError);
+			set.status = 500;
+			return { error: "Failed to check email sending limits" };
+		}
+
+		if (!emailCheck.allowed) {
+			set.status = 429;
+			return {
+				error: `Email sending limit does not cover ${items.length} more emails. Please upgrade your plan.`,
+			};
+		}
+
+		// Dedupe attachment processing across items sharing identical inputs;
+		// storage stays per-item so the worker reads a self-contained row.
+		const processedAttachmentsByItem: Array<ProcessedAttachment[]> = [];
+		const attachmentCache = new Map<string, ProcessedAttachment[]>();
+		for (let index = 0; index < items.length; index++) {
+			const item = items[index];
+			if (!item.attachments || item.attachments.length === 0) {
+				processedAttachmentsByItem.push([]);
+				continue;
+			}
+
+			const cacheKey = attachmentsCacheKey(item.attachments);
+			const cached = attachmentCache.get(cacheKey);
+			if (cached) {
+				processedAttachmentsByItem.push(cached);
+				continue;
+			}
+
+			try {
+				const processed = await processAttachments(item.attachments);
+				attachmentCache.set(cacheKey, processed);
+				processedAttachmentsByItem.push(processed);
+			} catch (attachmentError) {
+				set.status = 400;
+				return {
+					error: `emails[${index}]: ${
+						attachmentError instanceof Error
+							? attachmentError.message
+							: "Failed to process attachments"
+					}`,
+				};
+			}
+		}
+
+		// Aggregate stored-attachment cap: dedup above only saves processing
+		// work — every item row still persists its own copy, so 100 items
+		// repeating a 25MB attachment would otherwise write gigabytes into
+		// sent_emails. Measure the exact serialized bytes per row (duplicates
+		// included) and reject before creating any batch state.
+		const serializedAttachmentsByItem: Array<string | null> =
+			processedAttachmentsByItem.map((processed) =>
+				processed.length > 0
+					? JSON.stringify(attachmentsToStorageFormat(processed))
+					: null,
+			);
+		const storedAttachmentBytes = totalStoredAttachmentBytes(
+			serializedAttachmentsByItem,
+		);
+		if (storedAttachmentBytes > MAX_BULK_STORED_ATTACHMENT_BYTES) {
+			const gotMib = (storedAttachmentBytes / (1024 * 1024)).toFixed(1);
+			const maxMib = Math.floor(
+				MAX_BULK_STORED_ATTACHMENT_BYTES / (1024 * 1024),
+			);
+			set.status = 400;
+			return {
+				error: `Batch attachment payload too large: ${gotMib}MiB stored across all emails (max ${maxMib}MiB per batch, counting each email's attachments separately). Reduce attachment sizes or split the batch.`,
+			};
+		}
+
+		const batchId = nanoid();
+		const now = new Date();
+		const batchRow = {
+			id: batchId,
+			userId,
+			status: EMAIL_BATCH_STATUS.QUEUED,
+			total: items.length,
+			scheduledAt: parsedDate?.date ?? null,
+			timezone: parsedDate?.timezone ?? null,
+			idempotencyKey: idempotencyKey ?? null,
+			createdAt: now,
+			updatedAt: now,
+		};
+
+		let createdBatch: EmailBatch;
+		if (idempotencyKey) {
+			const inserted = await db
+				.insert(emailBatches)
+				.values(batchRow)
+				.onConflictDoNothing({
+					target: [emailBatches.userId, emailBatches.idempotencyKey],
+				})
+				.returning();
+
+			if (inserted.length === 0) {
+				const [existingBatch] = await db
+					.select()
+					.from(emailBatches)
+					.where(
+						and(
+							eq(emailBatches.userId, userId),
+							eq(emailBatches.idempotencyKey, idempotencyKey),
+						),
+					)
+					.limit(1);
+
+				if (!existingBatch) {
+					set.status = 500;
+					return { error: "Failed to create batch" };
+				}
+
+				// A row that appeared between the pre-check and this insert is
+				// seconds old, so recreation (stale cleanup) is never valid here.
+				const outcome = await respondForExistingBatch(
+					existingBatch,
+					queueConfig,
+					{ allowRecreate: false },
+				);
+				if (outcome.kind === "response") {
+					console.log(
+						"♻️ Concurrent idempotent bulk request - replaying batch:",
+						existingBatch.id,
+						"status:",
+						outcome.status,
+					);
+					set.status = outcome.status;
+					return outcome.body;
+				}
+				set.status = 409;
+				return { error: CREATION_IN_PROGRESS_ERROR };
+			}
+			createdBatch = inserted[0];
+		} else {
+			const inserted = await db
+				.insert(emailBatches)
+				.values(batchRow)
+				.returning();
+			createdBatch = inserted[0];
+		}
+
+		const itemRows: NewSentEmail[] = items.map((item, index) => {
+			// Validation guarantees exactly one 'to' recipient and no cc/bcc,
+			// so each row is exactly one recipient for accounting purposes.
+			const toAddresses = toAddressArray(item.to);
+			const replyToAddresses = toAddressArray(item.reply_to);
+
+			return {
+				id: nanoid(),
+				from: item.from,
+				fromAddress: extractEmailAddress(item.from),
+				fromDomain: extractDomain(item.from),
+				to: JSON.stringify(toAddresses),
+				cc: null,
+				bcc: null,
+				replyTo:
+					replyToAddresses.length > 0 ? JSON.stringify(replyToAddresses) : null,
+				subject: item.subject,
+				textBody: item.text ?? null,
+				htmlBody: item.html ?? null,
+				headers: item.headers ? JSON.stringify(item.headers) : null,
+				attachments: serializedAttachmentsByItem[index],
+				tags: item.tags ? JSON.stringify(item.tags) : null,
+				status: BULK_EMAIL_ITEM_STATUS.QUEUED,
+				userId,
+				batchId,
+				batchIndex: index,
+				createdAt: now,
+				updatedAt: now,
+			};
+		});
+
+		try {
+			const chunkSize = 25;
+			for (let start = 0; start < itemRows.length; start += chunkSize) {
+				await db
+					.insert(sentEmails)
+					.values(itemRows.slice(start, start + chunkSize));
+			}
+		} catch (insertError) {
+			console.error("❌ Failed to persist bulk items:", insertError);
+			try {
+				await db.delete(sentEmails).where(eq(sentEmails.batchId, batchId));
+				await db.delete(emailBatches).where(eq(emailBatches.id, batchId));
+			} catch (cleanupError) {
+				console.error("❌ Failed to clean up partial batch:", cleanupError);
+			}
+			set.status = 500;
+			return { error: "Failed to persist batch items" };
+		}
+
+		const notBefore = parsedDate
+			? Math.floor(parsedDate.date.getTime() / 1000)
+			: undefined;
+
+		// Publication must skip items a racing cancel already flipped: the
+		// worker's CAS claim would refuse them anyway, but we avoid creating
+		// queue messages for cancelled rows at all. If the re-read fails,
+		// fall back to the rows we just inserted (all queued moments ago).
+		let publishableRows = itemRows.map((row) => ({
+			id: row.id as string,
+			batchIndex: row.batchIndex as number,
+		}));
+		try {
+			const currentItems = await db
+				.select({
+					id: sentEmails.id,
+					batchIndex: sentEmails.batchIndex,
+					status: sentEmails.status,
+				})
+				.from(sentEmails)
+				.where(
+					and(eq(sentEmails.batchId, batchId), eq(sentEmails.userId, userId)),
+				);
+			publishableRows = currentItems
+				.filter((item) => isBulkItemClaimable(item.status))
+				.map((item) => ({
+					id: item.id,
+					batchIndex: item.batchIndex ?? 0,
+				}));
+		} catch (rereadError) {
+			console.error(
+				"⚠️ Pre-publish item re-read failed, publishing inserted rows:",
+				rereadError,
+			);
+		}
+
+		const outcome = await publishBulkQueueMessages({
+			config: queueConfig,
+			userId,
+			batchId,
+			entries: publishableRows,
+			notBefore,
+		});
+
+		if (outcome.publishedCount > 0) {
+			await mergeBatchQstashMessageIds(batchId, outcome.messageIdMap);
+		}
+
+		const unconfirmedQueued = publishableRows.filter(
+			(row) => !outcome.messageIdMap[row.id],
+		).length;
+
+		// Never resurrects a batch cancelled while we were publishing: the
+		// state update only touches queued/partially_queued parents.
+		await applyBatchPublicationState({
+			batchId,
+			unconfirmedQueuedCount: unconfirmedQueued,
+			errorMessage:
+				unconfirmedQueued > 0
+					? `${unconfirmedQueued} of ${publishableRows.length} email(s) are stored but not yet queued for delivery${outcome.errorMessage ? `: ${outcome.errorMessage}` : ""}. Retry the request with the same Idempotency-Key to publish the remainder, or cancel the batch.`
+					: null,
+		});
+
+		// Total publication failure: the batch and all items are durable and
+		// still 'queued', but nothing has been handed to the delivery queue.
+		// Answer retryable so the caller replays under the same
+		// Idempotency-Key (which republishes) instead of trusting a 202.
+		if (publishableRows.length > 0 && outcome.publishedCount === 0) {
+			console.error("❌ Bulk batch publication failed entirely:", {
+				batchId,
+				total: itemRows.length,
+				error: outcome.errorMessage,
+			});
+			set.status = 503;
+			return {
+				error: `Batch ${batchId} was stored durably (status: partially_queued) but none of its ${publishableRows.length} email(s) could be queued for delivery. Retry this request with the same Idempotency-Key to publish them, or cancel the batch via POST /emails/bulk/${batchId}/cancel.`,
+			};
+		}
+
+		let finalStatus: string =
+			unconfirmedQueued === 0
+				? EMAIL_BATCH_STATUS.QUEUED
+				: EMAIL_BATCH_STATUS.PARTIALLY_QUEUED;
+
+		// A cancel that raced this creation (possible once a concurrent
+		// replay exposed the batch id) flipped items to cancelled; report
+		// the parent's actual status instead of pretending it is queued.
+		if (publishableRows.length < itemRows.length) {
+			const [freshBatch] = await db
+				.select({ status: emailBatches.status })
+				.from(emailBatches)
+				.where(eq(emailBatches.id, batchId))
+				.limit(1);
+			if (freshBatch) {
+				finalStatus = freshBatch.status;
+			}
+		}
+
+		console.log("✅ Bulk batch accepted:", {
+			batchId,
+			total: itemRows.length,
+			publishedCount: outcome.publishedCount,
+			unconfirmedQueued,
+			status: finalStatus,
+		});
+
+		set.status = 202;
+		return buildBulkAcceptedResponse(
+			{
+				id: createdBatch.id,
+				status: finalStatus,
+				total: createdBatch.total,
+				scheduledAt: createdBatch.scheduledAt,
+				timezone: createdBatch.timezone,
+			},
+			itemRows.map((row) => ({
+				id: row.id as string,
+				batchIndex: row.batchIndex as number,
+			})),
+		);
+	},
+	{
+		body: SendBulkEmailBodySchema,
+		response: {
+			202: BulkAcceptedResponse,
+			400: ErrorResponse,
+			401: ErrorResponse,
+			403: ErrorResponse,
+			409: ErrorResponse,
+			429: ErrorResponse,
+			500: ErrorResponse,
+			503: ErrorResponse,
+		},
+		detail: {
+			hide: true,
+			tags: ["Emails"],
+			summary: "Send emails in bulk (internal)",
+			description:
+				"Accepts up to 100 emails (exactly one recipient each; cc/bcc are rejected), persists them durably, and queues each for delivery. Supports batch-level scheduled_at/timezone and an Idempotency-Key header.",
+		},
+	},
+);

--- a/app/api/e2/emails/send.ts
+++ b/app/api/e2/emails/send.ts
@@ -62,15 +62,15 @@ if (awsAccessKeyId && awsSecretAccessKey) {
 	});
 }
 
-// Request schema
-const AttachmentSchema = t.Object({
+// Request schema (shared with bulk send)
+export const AttachmentSchema = t.Object({
 	filename: t.String(),
 	content: t.String(),
 	content_type: t.Optional(t.String()),
 	path: t.Optional(t.String()),
 });
 
-const TagSchema = t.Object({
+export const TagSchema = t.Object({
 	name: t.String(),
 	value: t.String(),
 });

--- a/app/api/webhooks/send-email/route.ts
+++ b/app/api/webhooks/send-email/route.ts
@@ -1,11 +1,26 @@
-import { SESv2Client, SendEmailCommand } from "@aws-sdk/client-sesv2";
+import {
+	SESv2Client,
+	SendEmailCommand,
+	type SendEmailCommandOutput,
+} from "@aws-sdk/client-sesv2";
 import { Receiver } from "@upstash/qstash";
 import { waitUntil } from "@vercel/functions";
-import { eq } from "drizzle-orm";
+import { Autumn as autumn } from "autumn-js";
+import { and, eq, inArray, isNull, notExists, sql } from "drizzle-orm";
 import { nanoid } from "nanoid";
 import { type NextRequest, NextResponse } from "next/server";
+import {
+	bulkHourlyRetryDeduplicationId,
+	computeHourlyLimitRetryAtSeconds,
+	isRetryableSesThrottlingError,
+} from "@/app/api/e2/emails/bulk-helpers";
+import {
+	getBulkQueueConfig,
+	mergeBatchQstashMessageIds,
+	publishBulkQueueMessages,
+} from "@/app/api/e2/emails/bulk-queue";
+import type { ProcessedAttachment } from "@/app/api/e2/helper/attachment-processor";
 import { buildSentEmailTags } from "@/app/api/e2/helper/ses-email-tags";
-import type { PostEmailsRequest } from "@/lib/api-types";
 import {
 	getAgentIdentityArn,
 	getTenantSendingInfoForDomainOrParent,
@@ -13,6 +28,9 @@ import {
 } from "@/lib/aws-ses/identity-arn-helper";
 import { db } from "@/lib/db";
 import {
+	BULK_EMAIL_ITEM_STATUS,
+	EMAIL_BATCH_STATUS,
+	emailBatches,
 	SCHEDULED_EMAIL_STATUS,
 	SENT_EMAIL_STATUS,
 	scheduledEmails,
@@ -23,6 +41,7 @@ import {
 	canUserSendFromEmail,
 	extractEmailAddress,
 } from "@/lib/email-management/agent-email-helper";
+import { checkRecipientsAgainstBlocklist } from "@/lib/email-management/email-blocking";
 import { evaluateSending } from "@/lib/email-management/email-evaluation";
 import { enforceOutboundSendGuard } from "@/lib/email-management/outbound-send-guard";
 import { checkSendingSpike } from "@/lib/email-management/sending-spike-detector";
@@ -72,7 +91,6 @@ interface QStashPayload {
 	scheduledEmailId?: string; // for scheduled
 	emailId?: string; // for batch
 	userId?: string; // for batch
-	emailData?: PostEmailsRequest; // for batch
 	batchId?: string; // for batch
 	batchIndex?: number; // for batch
 }
@@ -82,6 +100,361 @@ interface StoredAttachment {
 	contentType?: string;
 	content_type?: string;
 	[key: string]: unknown;
+}
+
+function fallbackContentTypeForFilename(filename: string): string {
+	const ext = filename.toLowerCase().split(".").pop();
+	switch (ext) {
+		case "pdf":
+			return "application/pdf";
+		case "jpg":
+		case "jpeg":
+			return "image/jpeg";
+		case "png":
+			return "image/png";
+		case "gif":
+			return "image/gif";
+		case "txt":
+			return "text/plain";
+		case "html":
+			return "text/html";
+		case "json":
+			return "application/json";
+		case "zip":
+			return "application/zip";
+		case "doc":
+			return "application/msword";
+		case "docx":
+			return "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
+		case "xls":
+			return "application/vnd.ms-excel";
+		case "xlsx":
+			return "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+		default:
+			return "application/octet-stream";
+	}
+}
+
+/**
+ * Converts stored attachment rows (attachmentsToStorageFormat shape) back
+ * into the ProcessedAttachment shape buildRawEmailMessage expects, filling
+ * a content-type fallback for legacy rows that lack one.
+ */
+function normalizeStoredAttachments(
+	rawAttachments: StoredAttachment[],
+): ProcessedAttachment[] {
+	return rawAttachments.map((att, index) => {
+		let contentType = att.contentType || att.content_type;
+		if (!contentType) {
+			console.log(
+				`⚠️ Attachment ${index + 1} missing contentType, using fallback`,
+			);
+			contentType = fallbackContentTypeForFilename(att.filename || "unknown");
+		}
+
+		return {
+			content: typeof att.content === "string" ? att.content : "",
+			filename: att.filename || "unknown",
+			contentType,
+			size: typeof att.size === "number" ? att.size : 0,
+			...(typeof att.content_id === "string" && {
+				content_id: att.content_id,
+			}),
+		};
+	});
+}
+
+async function incrementBatchCounter(
+	batchId: string,
+	column: "sentCount" | "failedCount" | "cancelledCount",
+): Promise<void> {
+	try {
+		await db
+			.update(emailBatches)
+			.set(
+				column === "sentCount"
+					? {
+							sentCount: sql`${emailBatches.sentCount} + 1`,
+							updatedAt: new Date(),
+						}
+					: column === "failedCount"
+						? {
+								failedCount: sql`${emailBatches.failedCount} + 1`,
+								updatedAt: new Date(),
+							}
+						: {
+								cancelledCount: sql`${emailBatches.cancelledCount} + 1`,
+								updatedAt: new Date(),
+							},
+			)
+			.where(eq(emailBatches.id, batchId));
+
+		// Last finisher flips the batch to completed. Counters are advisory;
+		// the flip condition re-reads them atomically inside one statement.
+		await db
+			.update(emailBatches)
+			.set({
+				status: EMAIL_BATCH_STATUS.COMPLETED,
+				completedAt: new Date(),
+				updatedAt: new Date(),
+			})
+			.where(
+				and(
+					eq(emailBatches.id, batchId),
+					inArray(emailBatches.status, [
+						EMAIL_BATCH_STATUS.QUEUED,
+						EMAIL_BATCH_STATUS.PARTIALLY_QUEUED,
+					]),
+					sql`${emailBatches.sentCount} + ${emailBatches.failedCount} + ${emailBatches.cancelledCount} >= ${emailBatches.total}`,
+				),
+			);
+
+		// A batch cancelled while items were still processing keeps its
+		// CANCELLED status, but the last terminal item must still stamp
+		// completedAt so the batch reads as finished.
+		await db
+			.update(emailBatches)
+			.set({
+				completedAt: new Date(),
+				updatedAt: new Date(),
+			})
+			.where(
+				and(
+					eq(emailBatches.id, batchId),
+					eq(emailBatches.status, EMAIL_BATCH_STATUS.CANCELLED),
+					isNull(emailBatches.completedAt),
+					sql`${emailBatches.sentCount} + ${emailBatches.failedCount} + ${emailBatches.cancelledCount} >= ${emailBatches.total}`,
+				),
+			);
+	} catch (error) {
+		console.error("❌ Failed to update batch counters:", error);
+	}
+}
+
+async function failBulkItem(params: {
+	emailId: string;
+	batchId: string | null;
+	reason: string;
+	providerResponse?: string;
+}): Promise<void> {
+	const failedRows = await db
+		.update(sentEmails)
+		.set({
+			status: BULK_EMAIL_ITEM_STATUS.FAILED,
+			failureReason: params.reason,
+			...(params.providerResponse && {
+				providerResponse: params.providerResponse,
+			}),
+			updatedAt: new Date(),
+		})
+		.where(
+			and(
+				eq(sentEmails.id, params.emailId),
+				eq(sentEmails.status, BULK_EMAIL_ITEM_STATUS.PROCESSING),
+			),
+		)
+		.returning({ id: sentEmails.id });
+
+	if (params.batchId && failedRows.length > 0) {
+		await incrementBatchCounter(params.batchId, "failedCount");
+	}
+}
+
+type BulkRequeueOutcome = "requeued" | "cancelled" | "not_processing";
+
+/**
+ * Releases a worker claim without ever resurrecting work the user
+ * cancelled. A cancel that runs while an item is claimed ('processing')
+ * cannot flip that item, so a plain processing -> queued release would
+ * re-arm delivery for a CANCELLED parent. This single atomic statement
+ * decides the release target from the parent's current status: not
+ * cancelled -> back to 'queued'; cancelled -> straight to 'cancelled',
+ * with the parent's cancelled accounting corrected here (exactly once —
+ * the cancel endpoint never counted this item because it only counts the
+ * queued rows it flips itself, and the processing -> cancelled CAS can
+ * only ever succeed for one caller).
+ */
+async function requeueBulkItem(emailId: string): Promise<BulkRequeueOutcome> {
+	const releasedRows = await db
+		.update(sentEmails)
+		.set({
+			status: sql`CASE WHEN EXISTS (
+				SELECT 1 FROM ${emailBatches}
+				WHERE ${emailBatches.id} = ${sentEmails.batchId}
+				AND ${emailBatches.status} = ${EMAIL_BATCH_STATUS.CANCELLED}
+			) THEN ${BULK_EMAIL_ITEM_STATUS.CANCELLED} ELSE ${BULK_EMAIL_ITEM_STATUS.QUEUED} END`,
+			updatedAt: new Date(),
+		})
+		.where(
+			and(
+				eq(sentEmails.id, emailId),
+				eq(sentEmails.status, BULK_EMAIL_ITEM_STATUS.PROCESSING),
+			),
+		)
+		.returning({ status: sentEmails.status, batchId: sentEmails.batchId });
+
+	const released = releasedRows[0];
+	if (!released) {
+		return "not_processing";
+	}
+
+	if (released.status === BULK_EMAIL_ITEM_STATUS.CANCELLED) {
+		console.log(
+			"🛑 Parent batch was cancelled while item was claimed - item released as cancelled:",
+			emailId,
+		);
+		if (released.batchId) {
+			// Also stamps the parent's completedAt once every item is terminal.
+			await incrementBatchCounter(released.batchId, "cancelledCount");
+		}
+		return "cancelled";
+	}
+
+	return "requeued";
+}
+
+/**
+ * Best-effort claim release before answering 500. If even the release
+ * fails (DB fully down), the item is left 'processing'; log loudly because
+ * that state only heals via the same DB coming back before QStash retries
+ * run out.
+ */
+async function tryRequeueBulkItem(
+	emailId: string,
+): Promise<BulkRequeueOutcome | "error"> {
+	try {
+		return await requeueBulkItem(emailId);
+	} catch (requeueError) {
+		console.error(
+			"🚨 Failed to release bulk item claim - item may be stuck in 'processing':",
+			{ emailId, error: requeueError },
+		);
+		return "error";
+	}
+}
+
+/**
+ * Shared 200 response for transient paths that released a claim and found
+ * the parent batch cancelled: the item is now terminally 'cancelled', so
+ * QStash must not redeliver.
+ */
+function bulkItemCancelledResponse(emailId: string): NextResponse {
+	return NextResponse.json(
+		{ message: "Batch was cancelled; item will not be sent", emailId },
+		{ status: 200 },
+	);
+}
+
+/**
+ * Hourly send limit is transient capacity, not a failure: release the
+ * claim, then publish a delayed replacement that redelivers this item
+ * after the rolling hourly window has aged out. 200 is only returned once
+ * the replacement is confirmed; otherwise the item stays 'queued' and this
+ * delivery answers 500 so QStash retries the original message.
+ */
+async function rescheduleBulkItemForHourlyLimit(params: {
+	emailId: string;
+	userId: string;
+	batchId: string;
+	batchIndex: number;
+}): Promise<NextResponse> {
+	console.log(
+		"⏳ Hourly send limit reached for bulk item, rescheduling:",
+		params.emailId,
+	);
+
+	// Release the claim first: a crash after this point leaves the item
+	// 'queued', which the retried original delivery can claim again.
+	const released = await requeueBulkItem(params.emailId);
+
+	// Cancellation won while the item was claimed: it is now terminally
+	// 'cancelled', so no replacement may be published for it.
+	if (released === "cancelled") {
+		return bulkItemCancelledResponse(params.emailId);
+	}
+
+	if (released === "not_processing") {
+		// The claim vanished under us (external mutation). Do not publish a
+		// replacement for a row in an unknown state; abandoned-publication
+		// reconciliation recovers it if it is genuinely still queued.
+		console.error(
+			"🚨 Bulk item was not 'processing' while its claim was held, skipping reschedule:",
+			params.emailId,
+		);
+		return NextResponse.json(
+			{ message: "Item is no longer claimed; reschedule skipped" },
+			{ status: 200 },
+		);
+	}
+
+	const config = getBulkQueueConfig();
+	if (!config) {
+		console.error(
+			"❌ Cannot reschedule bulk item - queue is not configured:",
+			params.emailId,
+		);
+		return NextResponse.json(
+			{ error: "Hourly send limit reached and rescheduling is unavailable" },
+			{ status: 500 },
+		);
+	}
+
+	const retryAtSeconds = computeHourlyLimitRetryAtSeconds(Date.now());
+	const outcome = await publishBulkQueueMessages({
+		config,
+		userId: params.userId,
+		batchId: params.batchId,
+		entries: [
+			{
+				id: params.emailId,
+				batchIndex: params.batchIndex,
+				// Timestamped dedup id: never collides with the original
+				// message, reconcile republishes, or a later reschedule.
+				deduplicationId: bulkHourlyRetryDeduplicationId(
+					params.emailId,
+					retryAtSeconds,
+				),
+			},
+		],
+		notBefore: retryAtSeconds,
+	});
+
+	if (outcome.publishedCount === 0) {
+		console.error(
+			"❌ Failed to publish hourly-limit replacement, item stays queued for retry:",
+			{ emailId: params.emailId, error: outcome.errorMessage },
+		);
+		return NextResponse.json(
+			{
+				error: "Hourly send limit reached and rescheduling failed, will retry",
+			},
+			{ status: 500 },
+		);
+	}
+
+	try {
+		await mergeBatchQstashMessageIds(params.batchId, outcome.messageIdMap);
+	} catch (mergeError) {
+		// Non-fatal: the replacement exists; the id map only aids cancel and
+		// abandonment classification.
+		console.error(
+			"⚠️ Failed to record replacement message id (continuing):",
+			mergeError,
+		);
+	}
+
+	console.log("✅ Bulk item rescheduled past hourly window:", {
+		emailId: params.emailId,
+		notBefore: retryAtSeconds,
+	});
+	return NextResponse.json(
+		{
+			rescheduled: true,
+			emailId: params.emailId,
+			notBefore: retryAtSeconds,
+		},
+		{ status: 200 },
+	);
 }
 
 export async function POST(request: NextRequest) {
@@ -114,7 +487,7 @@ export async function POST(request: NextRequest) {
 
 		// Route to appropriate handler based on type
 		if (payload.type === "batch") {
-			return handleBatchEmail(request, payload, body);
+			return handleBulkEmailItem(payload);
 		} else if (payload.type === "scheduled") {
 			return handleScheduledEmail(payload);
 		} else {
@@ -258,71 +631,7 @@ async function handleScheduledEmail(payload: QStashPayload) {
 			: [];
 
 		// Validate and fix attachment data - ensure contentType is set
-		const attachments = rawAttachments.map(
-			(att: StoredAttachment, index: number) => {
-				if (!att.contentType && !att.content_type) {
-					console.log(
-						`⚠️ Attachment ${index + 1} missing contentType, using fallback`,
-					);
-					const filename = att.filename || "unknown";
-					const ext = filename.toLowerCase().split(".").pop();
-					let contentType = "application/octet-stream";
-
-					// Common file type mappings
-					switch (ext) {
-						case "pdf":
-							contentType = "application/pdf";
-							break;
-						case "jpg":
-						case "jpeg":
-							contentType = "image/jpeg";
-							break;
-						case "png":
-							contentType = "image/png";
-							break;
-						case "gif":
-							contentType = "image/gif";
-							break;
-						case "txt":
-							contentType = "text/plain";
-							break;
-						case "html":
-							contentType = "text/html";
-							break;
-						case "json":
-							contentType = "application/json";
-							break;
-						case "zip":
-							contentType = "application/zip";
-							break;
-						case "doc":
-							contentType = "application/msword";
-							break;
-						case "docx":
-							contentType =
-								"application/vnd.openxmlformats-officedocument.wordprocessingml.document";
-							break;
-						case "xls":
-							contentType = "application/vnd.ms-excel";
-							break;
-						case "xlsx":
-							contentType =
-								"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
-							break;
-					}
-
-					return {
-						...att,
-						contentType: contentType,
-					};
-				}
-
-				return {
-					...att,
-					contentType: att.contentType || att.content_type,
-				};
-			},
-		);
+		const attachments = normalizeStoredAttachments(rawAttachments);
 
 		// Create sent email record first (for tracking)
 		const sentEmailId = nanoid();
@@ -548,13 +857,9 @@ async function handleScheduledEmail(payload: QStashPayload) {
 	}
 }
 
-// Handler for batch emails
-async function handleBatchEmail(
-	_request: NextRequest,
-	payload: QStashPayload,
-	_body: string,
-) {
-	if (!payload.emailId || !payload.userId || !payload.emailData) {
+// Handler for bulk batch email items (payload carries durable IDs only)
+async function handleBulkEmailItem(payload: QStashPayload) {
+	if (!payload.emailId || !payload.userId || !payload.batchId) {
 		console.error("❌ QStash Webhook - Missing required batch fields");
 		return NextResponse.json(
 			{ error: "Missing required batch fields" },
@@ -563,9 +868,12 @@ async function handleBatchEmail(
 	}
 
 	const { emailId, userId, batchId, batchIndex } = payload;
-	console.log("📧 Processing batch email:", { emailId, batchId, batchIndex });
+	console.log("📧 Processing bulk email item:", {
+		emailId,
+		batchId,
+		batchIndex,
+	});
 
-	// Check if SES is configured
 	if (!sesClient) {
 		console.error("❌ AWS SES not configured");
 		return NextResponse.json(
@@ -576,242 +884,333 @@ async function handleBatchEmail(
 		);
 	}
 
-	// Fetch the pending sent email record
-	const [sentEmail] = await db
-		.select()
-		.from(sentEmails)
-		.where(eq(sentEmails.id, emailId))
-		.limit(1);
+	// Atomic compare-and-swap claim: exactly one QStash delivery moves the
+	// item from queued -> processing. Retries and concurrent deliveries lose
+	// the claim, so an item can never be sent twice. userId and batchId in
+	// the WHERE clause mean a mismatched or forged payload can never claim
+	// another user's row or a row outside its batch. The claim additionally
+	// requires the parent batch to not be CANCELLED, so an item that
+	// returned to 'queued' after the cancel's item pass ran (transient
+	// requeue, undeleted QStash message, hourly replacement) can never be
+	// claimed for delivery once the user's cancel has won.
+	const claimedRows = await db
+		.update(sentEmails)
+		.set({
+			status: BULK_EMAIL_ITEM_STATUS.PROCESSING,
+			updatedAt: new Date(),
+		})
+		.where(
+			and(
+				eq(sentEmails.id, emailId),
+				eq(sentEmails.userId, userId),
+				eq(sentEmails.batchId, batchId),
+				eq(sentEmails.status, BULK_EMAIL_ITEM_STATUS.QUEUED),
+				notExists(
+					db
+						.select({ one: sql`1` })
+						.from(emailBatches)
+						.where(
+							and(
+								eq(emailBatches.id, batchId),
+								eq(emailBatches.status, EMAIL_BATCH_STATUS.CANCELLED),
+							),
+						),
+				),
+			),
+		)
+		.returning();
 
-	if (!sentEmail) {
-		console.error("❌ Sent email not found:", emailId);
-		return NextResponse.json(
-			{ error: "Sent email not found" },
-			{ status: 400 },
-		);
-	}
-
-	const effectiveUserId = sentEmail.userId;
-	if (effectiveUserId !== userId) {
-		console.error("❌ QStash Webhook - Payload userId mismatch", {
-			emailId,
-			payloadUserId: userId,
-			recordUserId: effectiveUserId,
-		});
-		return NextResponse.json(
-			{ error: "Invalid batch payload user association" },
-			{ status: 400 },
-		);
-	}
-
-	// Check if already processed
-	if (sentEmail.status === SENT_EMAIL_STATUS.SENT) {
-		console.log("✅ Email already sent, skipping:", emailId);
-		return NextResponse.json(
-			{ message: "Email already sent" },
-			{ status: 200 },
-		);
-	}
-
-	if (sentEmail.status === SENT_EMAIL_STATUS.FAILED) {
-		console.log("⚠️ Email previously failed, retrying:", emailId);
-	}
-
-	const batchFromAddress = extractEmailAddress(sentEmail.from);
-	const { isAgentEmail: batchIsAgentEmail } = canUserSendFromEmail(
-		sentEmail.from,
-	);
-	const batchGuard = await enforceOutboundSendGuard({
-		userId: effectiveUserId,
-		fromAddress: batchFromAddress,
-		fromDomain: sentEmail.fromDomain,
-		isAgentEmail: batchIsAgentEmail,
-	});
-	if (!batchGuard.allowed) {
-		console.log(
-			`🚫 Blocking batch email for user ${effectiveUserId}: ${batchGuard.reasonCode}`,
-		);
-
-		// Update sent email status to failed
-		await db
-			.update(sentEmails)
-			.set({
-				status: SENT_EMAIL_STATUS.FAILED,
-				failureReason: `Email blocked: ${batchGuard.error || "Outbound security guard"}`,
-				updatedAt: new Date(),
+	if (claimedRows.length === 0) {
+		const [existing] = await db
+			.select({
+				id: sentEmails.id,
+				status: sentEmails.status,
+				userId: sentEmails.userId,
+				batchId: sentEmails.batchId,
 			})
-			.where(eq(sentEmails.id, emailId));
+			.from(sentEmails)
+			.where(eq(sentEmails.id, emailId))
+			.limit(1);
 
-		// Return 200 so QStash doesn't retry - this is intentional blocking
-		return NextResponse.json(
-			{
-				error: batchGuard.error || "Email blocked",
-				reason: batchGuard.reasonCode,
-			},
-			{ status: 200 },
-		);
-	}
+		if (
+			!existing ||
+			existing.userId !== userId ||
+			existing.batchId !== batchId
+		) {
+			console.error("❌ Bulk item not found or user/batch mismatch:", emailId);
+			return NextResponse.json(
+				{ error: "Bulk item not found" },
+				{ status: 400 },
+			);
+		}
 
-	try {
-		// Parse email data
-		const toAddresses = JSON.parse(sentEmail.to);
-		const ccAddresses = sentEmail.cc ? JSON.parse(sentEmail.cc) : [];
-		const bccAddresses = sentEmail.bcc ? JSON.parse(sentEmail.bcc) : [];
-		const replyToAddresses = sentEmail.replyTo
-			? JSON.parse(sentEmail.replyTo)
-			: [];
-		const headers = sentEmail.headers
-			? JSON.parse(sentEmail.headers)
-			: undefined;
-		const rawAttachments = sentEmail.attachments
-			? JSON.parse(sentEmail.attachments)
-			: [];
+		if (existing.status === BULK_EMAIL_ITEM_STATUS.QUEUED) {
+			const [parent] = await db
+				.select({ status: emailBatches.status })
+				.from(emailBatches)
+				.where(eq(emailBatches.id, batchId))
+				.limit(1);
 
-		// Validate and fix attachment data - ensure contentType is set
-		const attachments = rawAttachments.map(
-			(att: StoredAttachment, index: number) => {
-				if (!att.contentType && !att.content_type) {
+			if (parent?.status === EMAIL_BATCH_STATUS.CANCELLED) {
+				// Late cancel sweep: the claim was refused because the parent
+				// is CANCELLED. A queued item under a cancelled parent can
+				// never be claimed again, so finish the cancellation the
+				// cancel endpoint could not see (the item was 'processing'
+				// during its pass and was requeued afterwards). The CAS below
+				// makes the accounting increment exactly-once.
+				const sweptRows = await db
+					.update(sentEmails)
+					.set({
+						status: BULK_EMAIL_ITEM_STATUS.CANCELLED,
+						updatedAt: new Date(),
+					})
+					.where(
+						and(
+							eq(sentEmails.id, emailId),
+							eq(sentEmails.userId, userId),
+							eq(sentEmails.batchId, batchId),
+							eq(sentEmails.status, BULK_EMAIL_ITEM_STATUS.QUEUED),
+						),
+					)
+					.returning({ id: sentEmails.id });
+
+				if (sweptRows.length > 0) {
 					console.log(
-						`⚠️ Attachment ${index + 1} missing contentType, using fallback`,
+						"🛑 Cancelled orphaned queued item of cancelled batch:",
+						emailId,
 					);
-					const filename = att.filename || "unknown";
-					const ext = filename.toLowerCase().split(".").pop();
-					let contentType = "application/octet-stream";
-
-					// Common file type mappings
-					switch (ext) {
-						case "pdf":
-							contentType = "application/pdf";
-							break;
-						case "jpg":
-						case "jpeg":
-							contentType = "image/jpeg";
-							break;
-						case "png":
-							contentType = "image/png";
-							break;
-						case "gif":
-							contentType = "image/gif";
-							break;
-						case "txt":
-							contentType = "text/plain";
-							break;
-						case "html":
-							contentType = "text/html";
-							break;
-						case "json":
-							contentType = "application/json";
-							break;
-						case "zip":
-							contentType = "application/zip";
-							break;
-						case "doc":
-							contentType = "application/msword";
-							break;
-						case "docx":
-							contentType =
-								"application/vnd.openxmlformats-officedocument.wordprocessingml.document";
-							break;
-						case "xls":
-							contentType = "application/vnd.ms-excel";
-							break;
-						case "xlsx":
-							contentType =
-								"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
-							break;
-					}
-
-					return {
-						...att,
-						contentType: contentType,
-					};
+					await incrementBatchCounter(batchId, "cancelledCount");
 				}
 
-				return {
-					...att,
-					contentType: att.contentType || att.content_type,
-				};
-			},
-		);
+				return NextResponse.json(
+					{ message: "Batch is cancelled; item will not be sent" },
+					{ status: 200 },
+				);
+			}
 
-		// Build raw email message
-		console.log("📧 Building raw email message for batch email");
-		const rawMessage = buildRawEmailMessage({
-			from: sentEmail.from,
-			to: toAddresses,
-			cc: ccAddresses.length > 0 ? ccAddresses : undefined,
-			bcc: bccAddresses.length > 0 ? bccAddresses : undefined,
-			replyTo: replyToAddresses.length > 0 ? replyToAddresses : undefined,
-			subject: sentEmail.subject,
-			textBody: sentEmail.textBody || undefined,
-			htmlBody: sentEmail.htmlBody || undefined,
-			customHeaders: headers,
-			attachments: attachments,
-			date: new Date(),
+			// Phantom race: the CAS saw a non-claimable row but it reads
+			// 'queued' now (e.g. a concurrent transient requeue landed between
+			// the two statements). Let QStash redeliver and claim it properly
+			// instead of waiting for abandonment recovery.
+			console.warn(
+				"⚠️ Bulk item claim raced a concurrent release, retrying via QStash:",
+				emailId,
+			);
+			return NextResponse.json(
+				{ error: "Item claim raced a concurrent release, will retry" },
+				{ status: 500 },
+			);
+		}
+
+		// Terminal or in-flight states are final for this delivery: claimed
+		// items that crash mid-send stay 'processing' (visible via batch
+		// status) rather than risking a duplicate send on retry.
+		console.log(
+			`⏭️ Bulk item not claimable (status: ${existing.status}), skipping:`,
+			emailId,
+		);
+		return NextResponse.json(
+			{ message: `Item not claimable (status: ${existing.status})` },
+			{ status: 200 },
+		);
+	}
+
+	const item = claimedRows[0];
+	const itemBatchId = item.batchId;
+
+	// ---- Post-claim, pre-SES phase -------------------------------------
+	// Everything here happens provably before any SES call, so an
+	// unexpected exception releases the claim (item back to 'queued') and
+	// answers 500 for a QStash redelivery. Deliberate outcomes (permanent
+	// blocks, malformed content, hourly reschedule) return from inside.
+	let emailCheckUnlimited = false;
+	let toAddresses: string[] = [];
+	let rawCommand: SendEmailCommand;
+
+	try {
+		const bulkFromAddress = extractEmailAddress(item.from);
+		const { isAgentEmail: bulkIsAgentEmail } = canUserSendFromEmail(item.from);
+
+		// Re-check the outbound guard at execution time (hourly volume, bans,
+		// domain verification, tenant state may have changed since
+		// acceptance). deny_only: queued bulk work hitting the hourly cap is
+		// expected backpressure and must never pause the tenant — a pause
+		// would permanently fail every other queued item as tenant_inactive.
+		const bulkGuard = await enforceOutboundSendGuard({
+			userId,
+			fromAddress: bulkFromAddress,
+			fromDomain: item.fromDomain,
+			isAgentEmail: bulkIsAgentEmail,
+			hourlyLimitAction: "deny_only",
 		});
 
-		// Get the tenant sending info (identity ARN, configuration set, and tenant name) for tenant-level tracking
-		const batchFromDomain = sentEmail.fromDomain;
+		if (!bulkGuard.allowed) {
+			if (bulkGuard.reasonCode === "guard_check_failed") {
+				// Transient infrastructure failure before any send: release the
+				// claim and let QStash retry.
+				if ((await tryRequeueBulkItem(emailId)) === "cancelled") {
+					return bulkItemCancelledResponse(emailId);
+				}
+				return NextResponse.json(
+					{ error: bulkGuard.error || "Guard check failed" },
+					{ status: 500 },
+				);
+			}
 
-		let batchTenantInfo: TenantSendingInfo = {
+			if (bulkGuard.reasonCode === "hourly_send_limit_exceeded") {
+				// Transient capacity, not a failure: requeue and schedule a
+				// replacement delivery after the hourly window ages out.
+				return await rescheduleBulkItemForHourlyLimit({
+					emailId,
+					userId,
+					batchId,
+					batchIndex: item.batchIndex ?? batchIndex ?? 0,
+				});
+			}
+
+			console.log(
+				`🚫 Blocking bulk email for user ${userId}: ${bulkGuard.reasonCode}`,
+			);
+			await failBulkItem({
+				emailId,
+				batchId: itemBatchId,
+				reason: `Email blocked: ${bulkGuard.error || "Outbound security guard"}`,
+			});
+
+			// Return 200 so QStash doesn't retry - this is intentional blocking
+			return NextResponse.json(
+				{
+					error: bulkGuard.error || "Email blocked",
+					reason: bulkGuard.reasonCode,
+				},
+				{ status: 200 },
+			);
+		}
+
+		let ccAddresses: string[] = [];
+		let bccAddresses: string[] = [];
+		let replyToAddresses: string[] = [];
+		let headers: Record<string, string> | undefined;
+		let attachments: ProcessedAttachment[] = [];
+
+		try {
+			toAddresses = JSON.parse(item.to);
+			ccAddresses = item.cc ? JSON.parse(item.cc) : [];
+			bccAddresses = item.bcc ? JSON.parse(item.bcc) : [];
+			replyToAddresses = item.replyTo ? JSON.parse(item.replyTo) : [];
+			headers = item.headers ? JSON.parse(item.headers) : undefined;
+			attachments = normalizeStoredAttachments(
+				item.attachments ? JSON.parse(item.attachments) : [],
+			);
+		} catch (parseError) {
+			// Deterministic corruption: a retry cannot fix stored content, so
+			// fail permanently instead of looping through requeues.
+			console.error("❌ Failed to parse stored bulk item:", parseError);
+			await failBulkItem({
+				emailId,
+				batchId: itemBatchId,
+				reason: "Stored email content is malformed",
+			});
+			return NextResponse.json(
+				{ error: "Stored email content is malformed" },
+				{ status: 200 },
+			);
+		}
+
+		// Re-check recipients against the blocklist at execution time.
+		const blocklistCheck = await checkRecipientsAgainstBlocklist([
+			...toAddresses,
+			...ccAddresses,
+			...bccAddresses,
+		]);
+		if (blocklistCheck.hasBlockedRecipients) {
+			console.log(
+				`🚫 Blocked recipients in bulk item: ${blocklistCheck.blockedAddresses.join(", ")}`,
+			);
+			await failBulkItem({
+				emailId,
+				batchId: itemBatchId,
+				reason: `Blocked recipient(s): ${blocklistCheck.blockedAddresses.join(", ")}`,
+			});
+			return NextResponse.json(
+				{ error: "Recipients are blocked" },
+				{ status: 200 },
+			);
+		}
+
+		const { data: emailCheck, error: emailCheckError } = await autumn.check({
+			customer_id: userId,
+			feature_id: "emails_sent",
+			required_balance: 1,
+		});
+
+		if (emailCheckError) {
+			// Transient billing-service failure before any send: retry later.
+			console.error("❌ Autumn check error for bulk item:", emailCheckError);
+			if ((await tryRequeueBulkItem(emailId)) === "cancelled") {
+				return bulkItemCancelledResponse(emailId);
+			}
+			return NextResponse.json(
+				{ error: "Failed to check email sending limits" },
+				{ status: 500 },
+			);
+		}
+
+		if (!emailCheck.allowed) {
+			await failBulkItem({
+				emailId,
+				batchId: itemBatchId,
+				reason: "Email sending limit reached",
+			});
+			return NextResponse.json(
+				{ error: "Email sending limit reached" },
+				{ status: 200 },
+			);
+		}
+
+		emailCheckUnlimited = Boolean(emailCheck.unlimited);
+
+		let bulkTenantInfo: TenantSendingInfo = {
 			identityArn: null,
 			configurationSetName: null,
 			tenantName: null,
 		};
-		if (batchIsAgentEmail) {
-			batchTenantInfo = {
+		if (bulkIsAgentEmail) {
+			bulkTenantInfo = {
 				identityArn: getAgentIdentityArn(),
 				configurationSetName: null,
 				tenantName: null,
 			};
 		} else {
-			const batchParentDomain = isSubdomain(batchFromDomain)
-				? getRootDomain(batchFromDomain)
+			const bulkParentDomain = isSubdomain(item.fromDomain)
+				? getRootDomain(item.fromDomain)
 				: undefined;
-			batchTenantInfo = await getTenantSendingInfoForDomainOrParent(
-				effectiveUserId,
-				batchFromDomain,
-				batchParentDomain || undefined,
+			bulkTenantInfo = await getTenantSendingInfoForDomainOrParent(
+				userId,
+				item.fromDomain,
+				bulkParentDomain || undefined,
 			);
 		}
 
-		if (batchTenantInfo.identityArn) {
-			console.log(
-				`🏢 Using SourceArn for batch email tenant tracking: ${batchTenantInfo.identityArn}`,
-			);
-		} else {
-			console.warn(
-				"⚠️ No SourceArn available - batch email will not be tracked at tenant level",
-			);
-		}
+		console.log("📧 Building raw email message for bulk item");
+		const rawMessage = buildRawEmailMessage({
+			from: item.from,
+			to: toAddresses,
+			cc: ccAddresses.length > 0 ? ccAddresses : undefined,
+			bcc: bccAddresses.length > 0 ? bccAddresses : undefined,
+			replyTo: replyToAddresses.length > 0 ? replyToAddresses : undefined,
+			subject: item.subject,
+			textBody: item.textBody || undefined,
+			htmlBody: item.htmlBody || undefined,
+			customHeaders: headers,
+			attachments: attachments,
+			date: new Date(),
+		});
 
-		if (batchTenantInfo.configurationSetName) {
-			console.log(
-				`📋 Using ConfigurationSet for batch email tenant tracking: ${batchTenantInfo.configurationSetName}`,
-			);
-		} else {
-			console.warn(
-				"⚠️ No ConfigurationSet available - batch email metrics may not be tracked correctly",
-			);
-		}
-
-		if (batchTenantInfo.tenantName) {
-			console.log(
-				`🏠 Using TenantName for batch email AWS SES tracking: ${batchTenantInfo.tenantName}`,
-			);
-		} else {
-			console.warn(
-				"⚠️ No TenantName available - batch email will NOT appear in tenant dashboard!",
-			);
-		}
-
-		// Send via AWS SES using SESv2 SendEmailCommand with TenantName
-		// Per AWS docs: https://docs.aws.amazon.com/ses/latest/dg/tenants.html
-		// Use sentEmail.from (with display name) for proper sender name display
-		const rawCommand = new SendEmailCommand({
-			FromEmailAddress: sentEmail.from,
-			...(batchTenantInfo.identityArn && {
-				FromEmailAddressIdentityArn: batchTenantInfo.identityArn,
+		rawCommand = new SendEmailCommand({
+			FromEmailAddress: item.from,
+			...(bulkTenantInfo.identityArn && {
+				FromEmailAddressIdentityArn: bulkTenantInfo.identityArn,
 			}),
 			Destination: {
 				ToAddresses: toAddresses.map(extractEmailAddress),
@@ -829,22 +1228,91 @@ async function handleBatchEmail(
 					Data: Buffer.from(rawMessage),
 				},
 			},
-			...(batchTenantInfo.configurationSetName && {
-				ConfigurationSetName: batchTenantInfo.configurationSetName,
+			...(bulkTenantInfo.configurationSetName && {
+				ConfigurationSetName: bulkTenantInfo.configurationSetName,
 			}),
-			...(batchTenantInfo.tenantName && {
-				TenantName: batchTenantInfo.tenantName,
+			...(bulkTenantInfo.tenantName && {
+				TenantName: bulkTenantInfo.tenantName,
 			}),
 			EmailTags: buildSentEmailTags(emailId),
 		});
+	} catch (preSendError) {
+		// Nothing has been handed to SES yet, so releasing the claim for a
+		// retry is safe.
+		console.error("❌ Bulk item pre-send step failed:", preSendError);
+		if ((await tryRequeueBulkItem(emailId)) === "cancelled") {
+			return bulkItemCancelledResponse(emailId);
+		}
+		return NextResponse.json(
+			{
+				error: "Failed to prepare bulk email",
+				details:
+					preSendError instanceof Error
+						? preSendError.message
+						: "Unknown error",
+			},
+			{ status: 500 },
+		);
+	}
 
-		const sesResponse = await sesClient.send(rawCommand);
-		const messageId = sesResponse.MessageId;
+	// ---- SES call: the only operation with an ambiguous failure mode ----
+	let sesResponse: SendEmailCommandOutput;
+	try {
+		sesResponse = await sesClient.send(rawCommand);
+	} catch (sesError) {
+		console.error("❌ QStash Webhook - Error sending bulk item:", sesError);
 
-		console.log("✅ Batch email sent successfully via SES:", messageId);
+		const errorMessage =
+			sesError instanceof Error ? sesError.message : "Unknown SES error";
 
-		// Update sent email record with success
-		await db
+		// SES throttling (TooManyRequestsException / ThrottlingException /
+		// HTTP 429 / explicit throttling retry metadata) rejects the request
+		// before accepting the message, so releasing the claim for a QStash
+		// retry cannot double-send.
+		if (isRetryableSesThrottlingError(sesError)) {
+			console.log("🔁 SES throttled bulk item, requeueing for retry:", emailId);
+			if ((await tryRequeueBulkItem(emailId)) === "cancelled") {
+				return bulkItemCancelledResponse(emailId);
+			}
+			return NextResponse.json(
+				{
+					error: "SES throttled the send, will retry",
+					details: errorMessage,
+				},
+				{ status: 500 },
+			);
+		}
+
+		// Any other failure of the send call is ambiguous (the message may
+		// have been accepted despite the error), so the item fails
+		// permanently instead of being retried - same bias as single send.
+		await failBulkItem({
+			emailId,
+			batchId: itemBatchId,
+			reason: errorMessage,
+			providerResponse: JSON.stringify(sesError),
+		});
+
+		return NextResponse.json(
+			{
+				error: "Failed to send bulk email",
+				details: errorMessage,
+			},
+			{ status: 200 },
+		);
+	}
+
+	// ---- Post-SES phase: the mail is delivered (or being delivered). ----
+	// Nothing below may mark the item FAILED or requeue it: answering 500
+	// here would make QStash redeliver and risk a duplicate send. Failures
+	// are logged with enough context for manual reconciliation and the item
+	// stays 'processing' (status endpoint shows it honestly as in-flight).
+	const messageId = sesResponse.MessageId;
+	console.log("✅ Bulk email sent successfully via SES:", messageId);
+
+	let persistenceFailed = false;
+	try {
+		const sentRows = await db
 			.update(sentEmails)
 			.set({
 				status: SENT_EMAIL_STATUS.SENT,
@@ -853,86 +1321,78 @@ async function handleBatchEmail(
 				sentAt: new Date(),
 				updatedAt: new Date(),
 			})
-			.where(eq(sentEmails.id, emailId));
+			.where(
+				and(
+					eq(sentEmails.id, emailId),
+					eq(sentEmails.status, BULK_EMAIL_ITEM_STATUS.PROCESSING),
+				),
+			)
+			.returning({ id: sentEmails.id });
 
-		// Track email usage with Autumn (blocking - every email must count towards quota)
-		try {
-			const { Autumn: autumn } = await import("autumn-js");
-			const { data: emailCheck } = await autumn.check({
-				customer_id: effectiveUserId,
-				feature_id: "emails_sent",
-			});
-
-			if (emailCheck && !emailCheck.unlimited) {
-				console.log("📊 Tracking email usage with Autumn");
-				const { error: trackError } = await autumn.track({
-					customer_id: effectiveUserId,
-					feature_id: "emails_sent",
-					value: 1,
-				});
-
-				if (trackError) {
-					console.error("❌ Failed to track email usage:", trackError);
-					// Don't fail the request if tracking fails, but log it
-				}
-			}
-		} catch (trackError) {
-			console.error("❌ Failed to track email usage:", trackError);
-			// Don't fail the request if tracking fails
+		if (itemBatchId && sentRows.length > 0) {
+			await incrementBatchCounter(itemBatchId, "sentCount");
 		}
-
-		// Evaluate email for security risks (non-blocking)
-		waitUntil(
-			evaluateSending(emailId, effectiveUserId, {
-				from: sentEmail.from,
-				to: toAddresses,
-				subject: sentEmail.subject,
-				textBody: sentEmail.textBody || undefined,
-				htmlBody: sentEmail.htmlBody || undefined,
-			}),
-		);
-
-		// Check for sending spikes (non-blocking)
-		waitUntil(checkSendingSpike(effectiveUserId));
-
-		console.log("✅ Batch email processed successfully:", emailId);
-
-		return NextResponse.json(
+	} catch (persistError) {
+		persistenceFailed = true;
+		console.error(
+			"🚨 Bulk email was SENT via SES but recording the send failed - leaving item 'processing' (NOT failed) to avoid a duplicate send:",
 			{
-				success: true,
-				emailId: emailId,
-				messageId: messageId,
+				emailId,
+				batchId: itemBatchId,
+				sesMessageId: messageId,
+				error: persistError,
 			},
-			{ status: 200 },
-		);
-	} catch (error) {
-		console.error("❌ QStash Webhook - Error processing batch email:", error);
-
-		const errorMessage =
-			error instanceof Error ? error.message : "Unknown error";
-
-		// Update sent email record with error
-		try {
-			await db
-				.update(sentEmails)
-				.set({
-					status: SENT_EMAIL_STATUS.FAILED,
-					failureReason: errorMessage,
-					providerResponse: JSON.stringify(error),
-					updatedAt: new Date(),
-				})
-				.where(eq(sentEmails.id, emailId));
-		} catch (updateError) {
-			console.error("❌ Failed to update error in database:", updateError);
-		}
-
-		// Return 500 so QStash will retry
-		return NextResponse.json(
-			{
-				error: "Failed to process batch email",
-				details: errorMessage,
-			},
-			{ status: 500 },
 		);
 	}
+
+	try {
+		if (!emailCheckUnlimited) {
+			console.log("📊 Tracking email usage with Autumn");
+			const { error: trackError } = await autumn.track({
+				customer_id: userId,
+				feature_id: "emails_sent",
+				value: 1,
+			});
+
+			if (trackError) {
+				console.error("❌ Failed to track email usage (email was sent):", {
+					emailId,
+					sesMessageId: messageId,
+					trackError,
+				});
+			}
+		}
+	} catch (trackError) {
+		console.error("❌ Failed to track email usage (email was sent):", {
+			emailId,
+			sesMessageId: messageId,
+			error: trackError,
+		});
+	}
+
+	// Evaluate email for security risks (non-blocking)
+	waitUntil(
+		evaluateSending(emailId, userId, {
+			from: item.from,
+			to: toAddresses,
+			subject: item.subject,
+			textBody: item.textBody || undefined,
+			htmlBody: item.htmlBody || undefined,
+		}),
+	);
+
+	// Check for sending spikes (non-blocking)
+	waitUntil(checkSendingSpike(userId));
+
+	console.log("✅ Bulk email item processed successfully:", emailId);
+
+	return NextResponse.json(
+		{
+			success: true,
+			emailId: emailId,
+			messageId: messageId,
+			...(persistenceFailed && { warning: "sent_but_not_recorded" }),
+		},
+		{ status: 200 },
+	);
 }

--- a/drizzle/0072_add_internal_bulk_email.sql
+++ b/drizzle/0072_add_internal_bulk_email.sql
@@ -1,0 +1,23 @@
+CREATE TABLE IF NOT EXISTS "email_batches" (
+	"id" varchar(255) PRIMARY KEY NOT NULL,
+	"user_id" varchar(255) NOT NULL,
+	"status" varchar(50) DEFAULT 'queued' NOT NULL,
+	"total" integer NOT NULL,
+	"sent_count" integer DEFAULT 0 NOT NULL,
+	"failed_count" integer DEFAULT 0 NOT NULL,
+	"cancelled_count" integer DEFAULT 0 NOT NULL,
+	"scheduled_at" timestamp,
+	"timezone" varchar(50),
+	"idempotency_key" varchar(256),
+	"qstash_message_ids" text,
+	"last_error" text,
+	"created_at" timestamp DEFAULT now(),
+	"updated_at" timestamp DEFAULT now(),
+	"completed_at" timestamp
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "email_batches_user_idempotency_key_unique" ON "email_batches" USING btree ("user_id","idempotency_key");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "email_batches_user_created_idx" ON "email_batches" USING btree ("user_id","created_at");--> statement-breakpoint
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "sent_emails_batch_id_batch_index_unique"
+	ON "sent_emails" USING btree ("batch_id","batch_index")
+	WHERE "sent_emails"."batch_id" IS NOT NULL;

--- a/drizzle/meta/0072_snapshot.json
+++ b/drizzle/meta/0072_snapshot.json
@@ -1,0 +1,6366 @@
+{
+  "id": "fa167157-e28f-4f6f-be12-c164aed713c8",
+  "prevId": "409c204c-e259-4886-ab80-852d1de0a3ef",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.apikey": {
+      "name": "apikey",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "config_id": {
+          "name": "config_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refill_interval": {
+          "name": "refill_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refill_amount": {
+          "name": "refill_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_refill_at": {
+          "name": "last_refill_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "rate_limit_enabled": {
+          "name": "rate_limit_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "rate_limit_time_window": {
+          "name": "rate_limit_time_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 86400000
+        },
+        "rate_limit_max": {
+          "name": "rate_limit_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 10
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "apikey_config_id_idx": {
+          "name": "apikey_config_id_idx",
+          "columns": [
+            {
+              "expression": "config_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "apikey_reference_id_idx": {
+          "name": "apikey_reference_id_idx",
+          "columns": [
+            {
+              "expression": "reference_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "apikey_key_idx": {
+          "name": "apikey_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "apikey_user_id_user_id_fk": {
+          "name": "apikey_user_id_user_id_fk",
+          "tableFrom": "apikey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blocked_emails": {
+      "name": "blocked_emails",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email_address": {
+          "name": "email_address",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain_id": {
+          "name": "domain_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blocked_by": {
+          "name": "blocked_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "blocked_emails_email_address_unique": {
+          "name": "blocked_emails_email_address_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email_address"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blocked_signup_domains": {
+      "name": "blocked_signup_domains",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "blocked_by": {
+          "name": "blocked_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "blocked_signup_domains_active_idx": {
+          "name": "blocked_signup_domains_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "blocked_signup_domains_domain_unique": {
+          "name": "blocked_signup_domains_domain_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "domain"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.campaign_links": {
+      "name": "campaign_links",
+      "schema": "",
+      "columns": {
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "campaign": {
+          "name": "campaign",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant": {
+          "name": "variant",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "home_clicks": {
+          "name": "home_clicks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "checkout_clicks": {
+          "name": "checkout_clicks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "first_clicked_at": {
+          "name": "first_clicked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_clicked_at": {
+          "name": "last_clicked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "campaign_links_campaign_idx": {
+          "name": "campaign_links_campaign_idx",
+          "columns": [
+            {
+              "expression": "campaign",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "campaign_links_customer_id_idx": {
+          "name": "campaign_links_customer_id_idx",
+          "columns": [
+            {
+              "expression": "customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.device_code": {
+      "name": "device_code",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "device_code": {
+          "name": "device_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_code": {
+          "name": "user_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_polled_at": {
+          "name": "last_polled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "polling_interval": {
+          "name": "polling_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "device_code_device_code_idx": {
+          "name": "device_code_device_code_idx",
+          "columns": [
+            {
+              "expression": "device_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "device_code_user_code_idx": {
+          "name": "device_code_user_code_idx",
+          "columns": [
+            {
+              "expression": "user_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "device_code_user_id_idx": {
+          "name": "device_code_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "device_code_expires_at_idx": {
+          "name": "device_code_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "device_code_user_id_user_id_fk": {
+          "name": "device_code_user_id_user_id_fk",
+          "tableFrom": "device_code",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.domain_dns_records": {
+      "name": "domain_dns_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "domain_id": {
+          "name": "domain_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_type": {
+          "name": "record_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_required": {
+          "name": "is_required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "is_verified": {
+          "name": "is_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "last_checked": {
+          "name": "last_checked",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_addresses": {
+      "name": "email_addresses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain_id": {
+          "name": "domain_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endpoint_id": {
+          "name": "endpoint_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "is_receipt_rule_configured": {
+          "name": "is_receipt_rule_configured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "receipt_rule_name": {
+          "name": "receipt_rule_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "email_addresses_address_unique": {
+          "name": "email_addresses_address_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "address"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_batches": {
+      "name": "email_batches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "total": {
+          "name": "total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_count": {
+          "name": "sent_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "failed_count": {
+          "name": "failed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cancelled_count": {
+          "name": "cancelled_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "qstash_message_ids": {
+          "name": "qstash_message_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "email_batches_user_idempotency_key_unique": {
+          "name": "email_batches_user_idempotency_key_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_batches_user_created_idx": {
+          "name": "email_batches_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_delivery_events": {
+      "name": "email_delivery_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bounce_type": {
+          "name": "bounce_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bounce_sub_type": {
+          "name": "bounce_sub_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_class": {
+          "name": "status_class",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_category": {
+          "name": "status_category",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diagnostic_code": {
+          "name": "diagnostic_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_recipient": {
+          "name": "failed_recipient",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "failed_recipient_domain": {
+          "name": "failed_recipient_domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_message_id": {
+          "name": "original_message_id",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_sent_email_id": {
+          "name": "original_sent_email_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_from": {
+          "name": "original_from",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_to": {
+          "name": "original_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_subject": {
+          "name": "original_subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_sent_at": {
+          "name": "original_sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dsn_email_id": {
+          "name": "dsn_email_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dsn_received_at": {
+          "name": "dsn_received_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reporting_mta": {
+          "name": "reporting_mta",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remote_mta": {
+          "name": "remote_mta",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domain_id": {
+          "name": "domain_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domain_name": {
+          "name": "domain_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tenant_name": {
+          "name": "tenant_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_taken": {
+          "name": "action_taken",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_taken_at": {
+          "name": "action_taken_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "added_to_blocklist": {
+          "name": "added_to_blocklist",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "blocklist_id": {
+          "name": "blocklist_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_dsn_content": {
+          "name": "raw_dsn_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_delivery_events_event_type_idx": {
+          "name": "email_delivery_events_event_type_idx",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_delivery_events_bounce_type_idx": {
+          "name": "email_delivery_events_bounce_type_idx",
+          "columns": [
+            {
+              "expression": "bounce_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_delivery_events_failed_recipient_idx": {
+          "name": "email_delivery_events_failed_recipient_idx",
+          "columns": [
+            {
+              "expression": "failed_recipient",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_delivery_events_failed_recipient_domain_idx": {
+          "name": "email_delivery_events_failed_recipient_domain_idx",
+          "columns": [
+            {
+              "expression": "failed_recipient_domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_delivery_events_user_id_idx": {
+          "name": "email_delivery_events_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_delivery_events_domain_id_idx": {
+          "name": "email_delivery_events_domain_id_idx",
+          "columns": [
+            {
+              "expression": "domain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_delivery_events_tenant_id_idx": {
+          "name": "email_delivery_events_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_delivery_events_status_code_idx": {
+          "name": "email_delivery_events_status_code_idx",
+          "columns": [
+            {
+              "expression": "status_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_delivery_events_created_at_idx": {
+          "name": "email_delivery_events_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_delivery_events_original_message_id_idx": {
+          "name": "email_delivery_events_original_message_id_idx",
+          "columns": [
+            {
+              "expression": "original_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_domains": {
+      "name": "email_domains",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verification_token": {
+          "name": "verification_token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "can_receive_emails": {
+          "name": "can_receive_emails",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "has_mx_records": {
+          "name": "has_mx_records",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "domain_provider": {
+          "name": "domain_provider",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_confidence": {
+          "name": "provider_confidence",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_dns_check": {
+          "name": "last_dns_check",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_ses_check": {
+          "name": "last_ses_check",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mail_from_domain": {
+          "name": "mail_from_domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mail_from_domain_status": {
+          "name": "mail_from_domain_status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mail_from_domain_verified_at": {
+          "name": "mail_from_domain_verified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_catch_all_enabled": {
+          "name": "is_catch_all_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "catch_all_webhook_id": {
+          "name": "catch_all_webhook_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "catch_all_endpoint_id": {
+          "name": "catch_all_endpoint_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "catch_all_receipt_rule_name": {
+          "name": "catch_all_receipt_rule_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receive_dmarc_emails": {
+          "name": "receive_dmarc_emails",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "email_domains_domain_unique": {
+          "name": "email_domains_domain_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "domain"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_groups": {
+      "name": "email_groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "endpoint_id": {
+          "name": "endpoint_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_address": {
+          "name": "email_address",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_sending_evaluations": {
+      "name": "email_sending_evaluations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email_id": {
+          "name": "email_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evaluation_result": {
+          "name": "evaluation_result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "risk_score": {
+          "name": "risk_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "flags": {
+          "name": "flags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_model": {
+          "name": "ai_model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "evaluation_time": {
+          "name": "evaluation_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt_tokens": {
+          "name": "prompt_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completion_tokens": {
+          "name": "completion_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_sending_evaluations_email_id_idx": {
+          "name": "email_sending_evaluations_email_id_idx",
+          "columns": [
+            {
+              "expression": "email_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_sending_evaluations_user_id_idx": {
+          "name": "email_sending_evaluations_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_sending_evaluations_created_at_idx": {
+          "name": "email_sending_evaluations_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_threads": {
+      "name": "email_threads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "root_message_id": {
+          "name": "root_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_subject": {
+          "name": "normalized_subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "participant_emails": {
+          "name": "participant_emails",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_count": {
+          "name": "message_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_threads_root_message_id_idx": {
+          "name": "email_threads_root_message_id_idx",
+          "columns": [
+            {
+              "expression": "root_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_threads_user_id_idx": {
+          "name": "email_threads_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_threads_last_message_at_idx": {
+          "name": "email_threads_last_message_at_idx",
+          "columns": [
+            {
+              "expression": "last_message_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.endpoint_deliveries": {
+      "name": "endpoint_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email_id": {
+          "name": "email_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endpoint_id": {
+          "name": "endpoint_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delivery_type": {
+          "name": "delivery_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_data": {
+          "name": "response_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "endpoint_deliveries_email_status_idx": {
+          "name": "endpoint_deliveries_email_status_idx",
+          "columns": [
+            {
+              "expression": "email_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "endpoint_deliveries_email_id_idx": {
+          "name": "endpoint_deliveries_email_id_idx",
+          "columns": [
+            {
+              "expression": "email_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "endpoint_deliveries_email_endpoint_unique": {
+          "name": "endpoint_deliveries_email_endpoint_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email_id",
+            "endpoint_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.endpoints": {
+      "name": "endpoints",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhook_format": {
+          "name": "webhook_format",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'inbound'"
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.guard_rules": {
+      "name": "guard_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "last_triggered_at": {
+          "name": "last_triggered_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_count": {
+          "name": "trigger_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "actions": {
+          "name": "actions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "guard_rules_user_id_idx": {
+          "name": "guard_rules_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "guard_rules_priority_idx": {
+          "name": "guard_rules_priority_idx",
+          "columns": [
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.imap_appended_messages": {
+      "name": "imap_appended_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_content": {
+          "name": "raw_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "imap_appended_messages_user_id_idx": {
+          "name": "imap_appended_messages_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "imap_appended_messages_user_id_user_id_fk": {
+          "name": "imap_appended_messages_user_id_user_id_fk",
+          "tableFrom": "imap_appended_messages",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.imap_credential_scopes": {
+      "name": "imap_credential_scopes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain_id": {
+          "name": "domain_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope_key": {
+          "name": "scope_key",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "imap_credential_scopes_credential_id_idx": {
+          "name": "imap_credential_scopes_credential_id_idx",
+          "columns": [
+            {
+              "expression": "credential_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "imap_credential_scopes_domain_id_idx": {
+          "name": "imap_credential_scopes_domain_id_idx",
+          "columns": [
+            {
+              "expression": "domain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "imap_credential_scopes_credential_id_imap_credentials_id_fk": {
+          "name": "imap_credential_scopes_credential_id_imap_credentials_id_fk",
+          "tableFrom": "imap_credential_scopes",
+          "tableTo": "imap_credentials",
+          "columnsFrom": [
+            "credential_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "imap_credential_scopes_domain_id_email_domains_id_fk": {
+          "name": "imap_credential_scopes_domain_id_email_domains_id_fk",
+          "tableFrom": "imap_credential_scopes",
+          "tableTo": "email_domains",
+          "columnsFrom": [
+            "domain_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "imap_credential_scopes_credential_scope_key_unique": {
+          "name": "imap_credential_scopes_credential_scope_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "credential_id",
+            "scope_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.imap_credentials": {
+      "name": "imap_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "login_address": {
+          "name": "login_address",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'mailbox'"
+        },
+        "access_mode": {
+          "name": "access_mode",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sending_mode": {
+          "name": "sending_mode",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scoped_domains'"
+        },
+        "sending_name": {
+          "name": "sending_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sending_address": {
+          "name": "sending_address",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "imap_credentials_user_id_idx": {
+          "name": "imap_credentials_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "imap_credentials_user_id_user_id_fk": {
+          "name": "imap_credentials_user_id_user_id_fk",
+          "tableFrom": "imap_credentials",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "imap_credentials_api_key_id_apikey_id_fk": {
+          "name": "imap_credentials_api_key_id_apikey_id_fk",
+          "tableFrom": "imap_credentials",
+          "tableTo": "apikey",
+          "columnsFrom": [
+            "api_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "imap_credentials_api_key_id_unique": {
+          "name": "imap_credentials_api_key_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "api_key_id"
+          ]
+        },
+        "imap_credentials_user_login_address_unique": {
+          "name": "imap_credentials_user_login_address_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "login_address"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.imap_mailbox_messages": {
+      "name": "imap_mailbox_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "mailbox_id": {
+          "name": "mailbox_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "structured_email_id": {
+          "name": "structured_email_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uid": {
+          "name": "uid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_source": {
+          "name": "raw_source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'structured'"
+        },
+        "flags": {
+          "name": "flags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'"
+        },
+        "internal_date": {
+          "name": "internal_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "modseq": {
+          "name": "modseq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "imap_mailbox_messages_mailbox_uid_idx": {
+          "name": "imap_mailbox_messages_mailbox_uid_idx",
+          "columns": [
+            {
+              "expression": "mailbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "uid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "imap_mailbox_messages_appended_reference_idx": {
+          "name": "imap_mailbox_messages_appended_reference_idx",
+          "columns": [
+            {
+              "expression": "raw_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "structured_email_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "imap_mailbox_messages_mailbox_id_imap_mailboxes_id_fk": {
+          "name": "imap_mailbox_messages_mailbox_id_imap_mailboxes_id_fk",
+          "tableFrom": "imap_mailbox_messages",
+          "tableTo": "imap_mailboxes",
+          "columnsFrom": [
+            "mailbox_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "imap_mailbox_messages_mailbox_uid_unique": {
+          "name": "imap_mailbox_messages_mailbox_uid_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "mailbox_id",
+            "uid"
+          ]
+        },
+        "imap_mailbox_messages_mailbox_email_unique": {
+          "name": "imap_mailbox_messages_mailbox_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "mailbox_id",
+            "structured_email_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.imap_mailboxes": {
+      "name": "imap_mailboxes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'INBOX'"
+        },
+        "uid_validity": {
+          "name": "uid_validity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uid_next": {
+          "name": "uid_next",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "modseq": {
+          "name": "modseq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "subscribed": {
+          "name": "subscribed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "imap_mailboxes_user_id_idx": {
+          "name": "imap_mailboxes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "imap_mailboxes_credential_id_idx": {
+          "name": "imap_mailboxes_credential_id_idx",
+          "columns": [
+            {
+              "expression": "credential_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "imap_mailboxes_user_id_user_id_fk": {
+          "name": "imap_mailboxes_user_id_user_id_fk",
+          "tableFrom": "imap_mailboxes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "imap_mailboxes_credential_id_imap_credentials_id_fk": {
+          "name": "imap_mailboxes_credential_id_imap_credentials_id_fk",
+          "tableFrom": "imap_mailboxes",
+          "tableTo": "imap_credentials",
+          "columnsFrom": [
+            "credential_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "imap_mailboxes_scope_id_imap_credential_scopes_id_fk": {
+          "name": "imap_mailboxes_scope_id_imap_credential_scopes_id_fk",
+          "tableFrom": "imap_mailboxes",
+          "tableTo": "imap_credential_scopes",
+          "columnsFrom": [
+            "scope_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "imap_mailboxes_user_address_path_unique": {
+          "name": "imap_mailboxes_user_address_path_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "address",
+            "path"
+          ]
+        },
+        "imap_mailboxes_credential_path_unique": {
+          "name": "imap_mailboxes_credential_path_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "credential_id",
+            "path"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.inbound_oauth_grants": {
+      "name": "inbound_oauth_grants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain_ids": {
+          "name": "domain_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "inbound_oauth_grants_user_id_idx": {
+          "name": "inbound_oauth_grants_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "inbound_oauth_grants_session_client_idx": {
+          "name": "inbound_oauth_grants_session_client_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "inbound_oauth_grants_user_id_user_id_fk": {
+          "name": "inbound_oauth_grants_user_id_user_id_fk",
+          "tableFrom": "inbound_oauth_grants",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "inbound_oauth_grants_session_id_session_id_fk": {
+          "name": "inbound_oauth_grants_session_id_session_id_fk",
+          "tableFrom": "inbound_oauth_grants",
+          "tableTo": "session",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "inbound_oauth_grants_client_id_oauth_client_client_id_fk": {
+          "name": "inbound_oauth_grants_client_id_oauth_client_client_id_fk",
+          "tableFrom": "inbound_oauth_grants",
+          "tableTo": "oauth_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jwks": {
+      "name": "jwks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_access_token": {
+      "name": "oauth_access_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_id": {
+          "name": "refresh_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauth_access_token_token_idx": {
+          "name": "oauth_access_token_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_access_token_client_id_idx": {
+          "name": "oauth_access_token_client_id_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_access_token_session_id_idx": {
+          "name": "oauth_access_token_session_id_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_access_token_user_id_idx": {
+          "name": "oauth_access_token_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_access_token_refresh_id_idx": {
+          "name": "oauth_access_token_refresh_id_idx",
+          "columns": [
+            {
+              "expression": "refresh_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_access_token_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_access_token_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_session_id_session_id_fk": {
+          "name": "oauth_access_token_session_id_session_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "session",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_user_id_user_id_fk": {
+          "name": "oauth_access_token_user_id_user_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_refresh_id_oauth_refresh_token_id_fk": {
+          "name": "oauth_access_token_refresh_id_oauth_refresh_token_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_refresh_token",
+          "columnsFrom": [
+            "refresh_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_client": {
+      "name": "oauth_client",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "skip_consent": {
+          "name": "skip_consent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enable_end_session": {
+          "name": "enable_end_session",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contacts": {
+          "name": "contacts",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tos": {
+          "name": "tos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "policy": {
+          "name": "policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_id": {
+          "name": "software_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_version": {
+          "name": "software_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_statement": {
+          "name": "software_statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_logout_redirect_uris": {
+          "name": "post_logout_redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grant_types": {
+          "name": "grant_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_types": {
+          "name": "response_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public": {
+          "name": "public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "require_pkce": {
+          "name": "require_pkce",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "oauth_client_user_id_idx": {
+          "name": "oauth_client_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_client_user_id_user_id_fk": {
+          "name": "oauth_client_user_id_user_id_fk",
+          "tableFrom": "oauth_client",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_client_client_id_unique": {
+          "name": "oauth_client_client_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "client_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_consent": {
+      "name": "oauth_consent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauth_consent_client_id_idx": {
+          "name": "oauth_consent_client_id_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_consent_user_id_idx": {
+          "name": "oauth_consent_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_consent_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_consent_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "oauth_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_consent_user_id_user_id_fk": {
+          "name": "oauth_consent_user_id_user_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_refresh_token": {
+      "name": "oauth_refresh_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked": {
+          "name": "revoked",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_time": {
+          "name": "auth_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauth_refresh_token_token_idx": {
+          "name": "oauth_refresh_token_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_refresh_token_client_id_idx": {
+          "name": "oauth_refresh_token_client_id_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_refresh_token_session_id_idx": {
+          "name": "oauth_refresh_token_session_id_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_refresh_token_user_id_idx": {
+          "name": "oauth_refresh_token_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_refresh_token_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_refresh_token_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "oauth_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_token_session_id_session_id_fk": {
+          "name": "oauth_refresh_token_session_id_session_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "session",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_token_user_id_user_id_fk": {
+          "name": "oauth_refresh_token_user_id_user_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.onboarding_demo_emails": {
+      "name": "onboarding_demo_emails",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_id": {
+          "name": "email_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipient_email": {
+          "name": "recipient_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "reply_received": {
+          "name": "reply_received",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "reply_from": {
+          "name": "reply_from",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_subject": {
+          "name": "reply_subject",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_body": {
+          "name": "reply_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_received_at": {
+          "name": "reply_received_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.parsed_emails": {
+      "name": "parsed_emails",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email_id": {
+          "name": "email_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_text": {
+          "name": "from_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_address": {
+          "name": "from_address",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_name": {
+          "name": "from_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_text": {
+          "name": "to_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_addresses": {
+          "name": "to_addresses",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cc_text": {
+          "name": "cc_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cc_addresses": {
+          "name": "cc_addresses",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bcc_text": {
+          "name": "bcc_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bcc_addresses": {
+          "name": "bcc_addresses",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_to_text": {
+          "name": "reply_to_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_to_addresses": {
+          "name": "reply_to_addresses",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text_body": {
+          "name": "text_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "html_body": {
+          "name": "html_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "in_reply_to": {
+          "name": "in_reply_to",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "references": {
+          "name": "references",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_date": {
+          "name": "email_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attachment_count": {
+          "name": "attachment_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "has_attachments": {
+          "name": "has_attachments",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "headers": {
+          "name": "headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_text_body": {
+          "name": "has_text_body",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "has_html_body": {
+          "name": "has_html_body",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "parse_success": {
+          "name": "parse_success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "parse_error": {
+          "name": "parse_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.passkey": {
+      "name": "passkey",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_type": {
+          "name": "device_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backed_up": {
+          "name": "backed_up",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aaguid": {
+          "name": "aaguid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "passkey_user_id_idx": {
+          "name": "passkey_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "passkey_credential_id_idx": {
+          "name": "passkey_credential_id_idx",
+          "columns": [
+            {
+              "expression": "credential_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "passkey_user_id_user_id_fk": {
+          "name": "passkey_user_id_user_id_fk",
+          "tableFrom": "passkey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rate_limit_overrides": {
+      "name": "rate_limit_overrides",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hourly_limit": {
+          "name": "hourly_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "rate_limit_overrides_user_id_unique": {
+          "name": "rate_limit_overrides_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.received_emails": {
+      "name": "received_emails",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ses_event_id": {
+          "name": "ses_event_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from": {
+          "name": "from",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to": {
+          "name": "to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient": {
+          "name": "recipient",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_parsed": {
+          "name": "from_parsed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_parsed": {
+          "name": "to_parsed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cc_parsed": {
+          "name": "cc_parsed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bcc_parsed": {
+          "name": "bcc_parsed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_to_parsed": {
+          "name": "reply_to_parsed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text_body": {
+          "name": "text_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "html_body": {
+          "name": "html_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_email_content": {
+          "name": "raw_email_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "in_reply_to": {
+          "name": "in_reply_to",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "references": {
+          "name": "references",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headers": {
+          "name": "headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_date": {
+          "name": "email_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scheduled_emails": {
+      "name": "scheduled_emails",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'UTC'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scheduled'"
+        },
+        "from_address": {
+          "name": "from_address",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_domain": {
+          "name": "from_domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_addresses": {
+          "name": "to_addresses",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cc_addresses": {
+          "name": "cc_addresses",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bcc_addresses": {
+          "name": "bcc_addresses",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_to_addresses": {
+          "name": "reply_to_addresses",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text_body": {
+          "name": "text_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "html_body": {
+          "name": "html_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headers": {
+          "name": "headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "max_attempts": {
+          "name": "max_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 3
+        },
+        "next_retry_at": {
+          "name": "next_retry_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "qstash_schedule_id": {
+          "name": "qstash_schedule_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "qstash_dlq_id": {
+          "name": "qstash_dlq_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_email_id": {
+          "name": "sent_email_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sent_emails": {
+      "name": "sent_emails",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "from": {
+          "name": "from",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_address": {
+          "name": "from_address",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_domain": {
+          "name": "from_domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to": {
+          "name": "to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cc": {
+          "name": "cc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bcc": {
+          "name": "bcc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_to": {
+          "name": "reply_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text_body": {
+          "name": "text_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "html_body": {
+          "name": "html_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headers": {
+          "name": "headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ses_message_id": {
+          "name": "ses_message_id",
+          "type": "varchar(300)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'ses'"
+        },
+        "provider_response": {
+          "name": "provider_response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_opened_at": {
+          "name": "first_opened_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_opened_at": {
+          "name": "last_opened_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thread_position": {
+          "name": "thread_position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "batch_id": {
+          "name": "batch_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "batch_index": {
+          "name": "batch_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sent_emails_thread_id_idx": {
+          "name": "sent_emails_thread_id_idx",
+          "columns": [
+            {
+              "expression": "thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sent_emails_user_created_idx": {
+          "name": "sent_emails_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sent_emails_user_status_created_idx": {
+          "name": "sent_emails_user_status_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sent_emails_user_first_opened_idx": {
+          "name": "sent_emails_user_first_opened_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "first_opened_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sent_emails_batch_id_batch_index_unique": {
+          "name": "sent_emails_batch_id_batch_index_unique",
+          "columns": [
+            {
+              "expression": "batch_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "batch_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sent_emails\".\"batch_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ses_events": {
+      "name": "ses_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_source": {
+          "name": "event_source",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_version": {
+          "name": "event_version",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination": {
+          "name": "destination",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "receipt_timestamp": {
+          "name": "receipt_timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processing_time_millis": {
+          "name": "processing_time_millis",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipients": {
+          "name": "recipients",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "spam_verdict": {
+          "name": "spam_verdict",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "virus_verdict": {
+          "name": "virus_verdict",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spf_verdict": {
+          "name": "spf_verdict",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dkim_verdict": {
+          "name": "dkim_verdict",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dmarc_verdict": {
+          "name": "dmarc_verdict",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "s3_bucket_name": {
+          "name": "s3_bucket_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "s3_object_key": {
+          "name": "s3_object_key",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_content": {
+          "name": "email_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "s3_content_fetched": {
+          "name": "s3_content_fetched",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "s3_content_size": {
+          "name": "s3_content_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "s3_error": {
+          "name": "s3_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "common_headers": {
+          "name": "common_headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_ses_event": {
+          "name": "raw_ses_event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lambda_context": {
+          "name": "lambda_context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhook_payload": {
+          "name": "webhook_payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ses_receipt_rules": {
+      "name": "ses_receipt_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "rule_name": {
+          "name": "rule_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rule_set_name": {
+          "name": "rule_set_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain_count": {
+          "name": "domain_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "max_capacity": {
+          "name": "max_capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 500
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ses_receipt_rules_rule_name_unique": {
+          "name": "ses_receipt_rules_rule_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "rule_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ses_tenants": {
+      "name": "ses_tenants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "aws_tenant_id": {
+          "name": "aws_tenant_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_name": {
+          "name": "tenant_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "configuration_set_name": {
+          "name": "configuration_set_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "reputation_policy": {
+          "name": "reputation_policy",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'strict'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ses_tenants_user_id_unique": {
+          "name": "ses_tenants_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "ses_tenants_aws_tenant_id_unique": {
+          "name": "ses_tenants_aws_tenant_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "aws_tenant_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.structured_emails": {
+      "name": "structured_emails",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email_id": {
+          "name": "email_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ses_event_id": {
+          "name": "ses_event_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipient": {
+          "name": "recipient",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_data": {
+          "name": "from_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_data": {
+          "name": "to_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cc_data": {
+          "name": "cc_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bcc_data": {
+          "name": "bcc_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_to_data": {
+          "name": "reply_to_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "in_reply_to": {
+          "name": "in_reply_to",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "references": {
+          "name": "references",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text_body": {
+          "name": "text_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "html_body": {
+          "name": "html_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_content": {
+          "name": "raw_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headers": {
+          "name": "headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parse_success": {
+          "name": "parse_success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "parse_error": {
+          "name": "parse_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "guard_blocked": {
+          "name": "guard_blocked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "guard_reason": {
+          "name": "guard_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "guard_rule_id": {
+          "name": "guard_rule_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "guard_action": {
+          "name": "guard_action",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "guard_metadata": {
+          "name": "guard_metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thread_position": {
+          "name": "thread_position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "structured_emails_message_id_idx": {
+          "name": "structured_emails_message_id_idx",
+          "columns": [
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structured_emails_thread_id_idx": {
+          "name": "structured_emails_thread_id_idx",
+          "columns": [
+            {
+              "expression": "thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structured_emails_user_created_idx": {
+          "name": "structured_emails_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structured_emails_user_id_idx": {
+          "name": "structured_emails_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structured_emails_guard_blocked_idx": {
+          "name": "structured_emails_guard_blocked_idx",
+          "columns": [
+            {
+              "expression": "guard_blocked",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "structured_emails_user_message_recipient_unique": {
+          "name": "structured_emails_user_message_recipient_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "message_id",
+            "recipient"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscriptions": {
+      "name": "subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "plan": {
+          "name": "plan",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "seats": {
+          "name": "seats",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trial_start": {
+          "name": "trial_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trial_end": {
+          "name": "trial_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhooks_to_endpoints_migrated": {
+          "name": "webhooks_to_endpoints_migrated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "feature_flags": {
+          "name": "feature_flags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "svix_app_id": {
+          "name": "svix_app_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_accounts": {
+      "name": "user_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_restricted_key": {
+          "name": "stripe_restricted_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_onboarding": {
+      "name": "user_onboarding",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_completed": {
+          "name": "is_completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "default_endpoint_created": {
+          "name": "default_endpoint_created",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_onboarding_user_id_unique": {
+          "name": "user_onboarding_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_deliveries": {
+      "name": "webhook_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email_id": {
+          "name": "email_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_code": {
+          "name": "response_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_body": {
+          "name": "response_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_time": {
+          "name": "delivery_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhooks": {
+      "name": "webhooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headers": {
+          "name": "headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timeout": {
+          "name": "timeout",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 30
+        },
+        "retry_attempts": {
+          "name": "retry_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 3
+        },
+        "last_used": {
+          "name": "last_used",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_deliveries": {
+          "name": "total_deliveries",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "successful_deliveries": {
+          "name": "successful_deliveries",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "failed_deliveries": {
+          "name": "failed_deliveries",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -505,6 +505,13 @@
       "when": 1786220537623,
       "tag": "0071_add_sent_email_open_tracking",
       "breakpoints": true
+    },
+    {
+      "idx": 72,
+      "version": "7",
+      "when": 1786234727137,
+      "tag": "0072_add_internal_bulk_email",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -1,3 +1,4 @@
+import { sql } from "drizzle-orm";
 import {
 	boolean,
 	index,
@@ -6,6 +7,7 @@ import {
 	text,
 	timestamp,
 	unique,
+	uniqueIndex,
 	varchar,
 } from "drizzle-orm/pg-core";
 import {
@@ -610,6 +612,13 @@ export const sentEmails = pgTable(
 			table.userId,
 			table.firstOpenedAt,
 		),
+		// Partial unique index: guarantees one row per (batch, position) and
+		// its batch_id prefix also serves batch lookups, so no separate
+		// batch_id index is needed. WHERE clause keeps the ~4.3GB table's
+		// non-batch rows (batch_id IS NULL) out of the index entirely.
+		batchIdIndexUnique: uniqueIndex("sent_emails_batch_id_batch_index_unique")
+			.on(table.batchId, table.batchIndex)
+			.where(sql`${table.batchId} IS NOT NULL`),
 	}),
 );
 
@@ -693,6 +702,65 @@ export const scheduledEmails = pgTable("scheduled_emails", {
 	sentAt: timestamp("sent_at"), // When the email was actually sent
 	sentEmailId: varchar("sent_email_id", { length: 255 }), // Reference to sentEmails after successful sending
 });
+
+// Email Batches table - durable parent record for bulk sends (items live in sentEmails via batchId/batchIndex)
+export const emailBatches = pgTable(
+	"email_batches",
+	{
+		id: varchar("id", { length: 255 }).primaryKey(),
+		userId: varchar("user_id", { length: 255 }).notNull(),
+
+		// Lifecycle: 'queued', 'partially_queued', 'completed', 'cancelled'
+		status: varchar("status", { length: 50 }).notNull().default("queued"),
+
+		// Item accounting (counters are advisory; item rows are the source of truth)
+		total: integer("total").notNull(),
+		sentCount: integer("sent_count").notNull().default(0),
+		failedCount: integer("failed_count").notNull().default(0),
+		cancelledCount: integer("cancelled_count").notNull().default(0),
+
+		// Batch-level scheduling (null = immediate)
+		scheduledAt: timestamp("scheduled_at"),
+		timezone: varchar("timezone", { length: 50 }),
+
+		// Idempotency (unique per user via index below)
+		idempotencyKey: varchar("idempotency_key", { length: 256 }),
+
+		// JSON object mapping item id -> QStash message id (for cancellation)
+		qstashMessageIds: text("qstash_message_ids"),
+		lastError: text("last_error"),
+
+		createdAt: timestamp("created_at").defaultNow(),
+		updatedAt: timestamp("updated_at").defaultNow(),
+		completedAt: timestamp("completed_at"),
+	},
+	(table) => ({
+		userIdempotencyUnique: uniqueIndex(
+			"email_batches_user_idempotency_key_unique",
+		).on(table.userId, table.idempotencyKey),
+		userCreatedIdx: index("email_batches_user_created_idx").on(
+			table.userId,
+			table.createdAt,
+		),
+	}),
+);
+
+export const EMAIL_BATCH_STATUS = {
+	QUEUED: "queued",
+	PARTIALLY_QUEUED: "partially_queued",
+	COMPLETED: "completed",
+	CANCELLED: "cancelled",
+} as const;
+
+// Per-item lifecycle for bulk items stored in sentEmails.status
+// ('sent'/'failed' intentionally overlap with SENT_EMAIL_STATUS)
+export const BULK_EMAIL_ITEM_STATUS = {
+	QUEUED: "queued",
+	PROCESSING: "processing",
+	SENT: "sent",
+	FAILED: "failed",
+	CANCELLED: "cancelled",
+} as const;
 
 // Email Sending Evaluations table - stores AI evaluations of sent emails for fraud monitoring
 export const emailSendingEvaluations = pgTable(
@@ -797,6 +865,8 @@ export type BlockedSignupDomain = typeof blockedSignupDomains.$inferSelect;
 export type NewBlockedSignupDomain = typeof blockedSignupDomains.$inferInsert;
 export type SentEmail = typeof sentEmails.$inferSelect;
 export type NewSentEmail = typeof sentEmails.$inferInsert;
+export type EmailBatch = typeof emailBatches.$inferSelect;
+export type NewEmailBatch = typeof emailBatches.$inferInsert;
 export type EmailSendingEvaluation =
 	typeof emailSendingEvaluations.$inferSelect;
 export type NewEmailSendingEvaluation =

--- a/lib/email-management/outbound-send-guard.ts
+++ b/lib/email-management/outbound-send-guard.ts
@@ -34,6 +34,25 @@ interface OutboundSendGuardInput {
 	fromAddress: string;
 	fromDomain: string;
 	isAgentEmail: boolean;
+	/**
+	 * What to do when the hourly send limit is hit.
+	 *
+	 * - "pause_tenant" (default): pause the tenant and alert admins. This is
+	 *   the historical single-send behavior: an interactive caller pushing
+	 *   past the cap is treated as a potential abuse signal.
+	 * - "deny_only": reject this send but leave the tenant untouched and skip
+	 *   admin alerts. Used by bulk queue processing, where hitting the cap is
+	 *   expected backpressure: queued work must be able to wait for the next
+	 *   hourly window without pausing the tenant (which would permanently
+	 *   fail every other queued item with tenant_inactive).
+	 * - "ignore": skip the hourly-volume denial entirely; every other check
+	 *   (ban, tenant state, domain verification, sender address) still runs
+	 *   and can deny. Used only when accepting FUTURE-scheduled bulk batches:
+	 *   the current rolling window says nothing about capacity at delivery
+	 *   time, and the worker re-checks with "deny_only" at execution and
+	 *   reschedules overflow past the window.
+	 */
+	hourlyLimitAction?: "pause_tenant" | "deny_only" | "ignore";
 }
 
 const ONE_HOUR_IN_MS = 60 * 60 * 1000;
@@ -264,10 +283,86 @@ function deny(
 	};
 }
 
+export interface HourlySendCapacity {
+	limit: number | null;
+	sentLastHour: number;
+	remaining: number | null;
+	windowStart: Date;
+	windowEnd: Date;
+}
+
+/**
+ * Remaining hourly send capacity for a user (limit null = unlimited).
+ * Shares the exact window/override semantics used by enforceOutboundSendGuard
+ * so bulk acceptance cannot admit more items than the guard would allow.
+ */
+export async function getHourlySendCapacity(
+	userId: string,
+): Promise<HourlySendCapacity> {
+	const windowEnd = new Date();
+	const windowStart = new Date(windowEnd.getTime() - ONE_HOUR_IN_MS);
+	const [hourlyCountResult] = await db
+		.select({
+			total: count(),
+		})
+		.from(sentEmails)
+		.where(
+			and(
+				eq(sentEmails.userId, userId),
+				eq(sentEmails.status, "sent"),
+				or(
+					gte(sentEmails.sentAt, windowStart),
+					and(
+						isNull(sentEmails.sentAt),
+						gte(sentEmails.createdAt, windowStart),
+					),
+				),
+			),
+		)
+		.limit(1);
+
+	const sentLastHour = Number(hourlyCountResult?.total || 0);
+
+	const [override] = await db
+		.select({
+			hourlyLimit: rateLimitOverrides.hourlyLimit,
+			expiresAt: rateLimitOverrides.expiresAt,
+		})
+		.from(rateLimitOverrides)
+		.where(
+			and(
+				eq(rateLimitOverrides.userId, userId),
+				eq(rateLimitOverrides.isActive, true),
+			),
+		)
+		.limit(1);
+
+	const isOverrideValid =
+		override &&
+		(!override.expiresAt || override.expiresAt.getTime() > Date.now());
+
+	// null hourlyLimit = unlimited (no cap)
+	const limit = isOverrideValid ? override.hourlyLimit : HOURLY_SEND_LIMIT;
+
+	return {
+		limit,
+		sentLastHour,
+		remaining: limit === null ? null : Math.max(0, limit - sentLastHour),
+		windowStart,
+		windowEnd,
+	};
+}
+
 export async function enforceOutboundSendGuard(
 	input: OutboundSendGuardInput,
 ): Promise<OutboundSendGuardResult> {
-	const { userId, fromAddress, fromDomain, isAgentEmail } = input;
+	const {
+		userId,
+		fromAddress,
+		fromDomain,
+		isAgentEmail,
+		hourlyLimitAction = "pause_tenant",
+	} = input;
 
 	try {
 		const [userRecord] = await db
@@ -324,69 +419,40 @@ export async function enforceOutboundSendGuard(
 			);
 		}
 
-		const windowEnd = new Date();
-		const windowStart = new Date(windowEnd.getTime() - ONE_HOUR_IN_MS);
-		const [hourlyCountResult] = await db
-			.select({
-				total: count(),
-			})
-			.from(sentEmails)
-			.where(
-				and(
-					eq(sentEmails.userId, userId),
-					eq(sentEmails.status, "sent"),
-					or(
-						gte(sentEmails.sentAt, windowStart),
-						and(
-							isNull(sentEmails.sentAt),
-							gte(sentEmails.createdAt, windowStart),
-						),
-					),
-				),
-			)
-			.limit(1);
+		const capacity = await getHourlySendCapacity(userId);
+		const { sentLastHour, windowStart, windowEnd } = capacity;
+		const effectiveLimit = capacity.limit;
 
-		const sentLastHour = Number(hourlyCountResult?.total || 0);
+		// effectiveLimit === null means unlimited — skip the check entirely.
+		// "ignore" skips only this denial (future-scheduled acceptance); all
+		// other guard checks above and below still apply.
+		if (
+			effectiveLimit !== null &&
+			sentLastHour >= effectiveLimit &&
+			hourlyLimitAction !== "ignore"
+		) {
+			if (hourlyLimitAction === "pause_tenant") {
+				await pauseTenantForHourlyLimit({
+					tenantId: userTenant.id,
+					configurationSetName: userTenant.configurationSetName,
+				});
 
-		const [override] = await db
-			.select({
-				hourlyLimit: rateLimitOverrides.hourlyLimit,
-				expiresAt: rateLimitOverrides.expiresAt,
-			})
-			.from(rateLimitOverrides)
-			.where(
-				and(
-					eq(rateLimitOverrides.userId, userId),
-					eq(rateLimitOverrides.isActive, true),
-				),
-			)
-			.limit(1);
-
-		const isOverrideValid =
-			override &&
-			(!override.expiresAt || override.expiresAt.getTime() > Date.now());
-
-		// null hourlyLimit = unlimited (no cap)
-		const effectiveLimit = isOverrideValid
-			? override.hourlyLimit
-			: HOURLY_SEND_LIMIT;
-
-		// effectiveLimit === null means unlimited — skip the check entirely
-		if (effectiveLimit !== null && sentLastHour >= effectiveLimit) {
-			await pauseTenantForHourlyLimit({
-				tenantId: userTenant.id,
-				configurationSetName: userTenant.configurationSetName,
-			});
-
-			await sendHourlyLimitAlert({
-				userId,
-				userEmail: userRecord.email,
-				tenantId: userTenant.id,
-				sentLastHour,
-				limit: effectiveLimit,
-				windowStart,
-				windowEnd,
-			});
+				await sendHourlyLimitAlert({
+					userId,
+					userEmail: userRecord.email,
+					tenantId: userTenant.id,
+					sentLastHour,
+					limit: effectiveLimit,
+					windowStart,
+					windowEnd,
+				});
+			} else {
+				// deny_only: expected backpressure (bulk queue). No pause, no
+				// admin alert - the caller reschedules the work instead.
+				console.log(
+					`⏳ Hourly send limit reached for user ${userId} (deny_only): ${sentLastHour}/${effectiveLimit} in the last hour`,
+				);
+			}
 
 			return deny(
 				429,


### PR DESCRIPTION
## Summary
- add hidden internal bulk email create, status, and cancellation endpoints
- persist durable batch state and queue one recipient per item through QStash
- prevent duplicate sends with atomic worker claims and cancellation-aware state transitions
- reconcile missing or abandoned queue publications through idempotent replay/status reads
- preserve sender, blocklist, hourly-volume, Autumn, tenant, SES tag, and open-tracking enforcement

## Internal API
- `POST /api/e2/emails/bulk`
- `GET /api/e2/emails/bulk/:id`
- `POST /api/e2/emails/bulk/:id/cancel`
- maximum 100 one-recipient items per batch
- optional batch-level `scheduled_at`

These routes are hidden from generated OpenAPI and no SDK/docs changes are included.

## Database
- generated migration `0072_add_internal_bulk_email.sql`
- creates `email_batches` and its indexes
- creates the partial unique `sent_emails(batch_id, batch_index)` index with `CONCURRENTLY` because `sent_emails` is approximately 4.3 GB
- migration is not applied by this PR

## Verification
- `bun test app/api/e2/emails/` - 66 passed
- focused adjacent tests - 71 passed
- Biome check on all changed TypeScript files - passed
- module-load smoke test - passed
- snapshot comparison found no unrelated schema drift

## Rollout
1. Apply migration 0072 manually before deployment.
2. Merge and deploy.
3. Exercise a small immediate batch, status read, cancellation, and scheduled batch before broader internal use.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches core outbound email delivery, QStash/SES concurrency, and duplicate-send edge cases; requires manual migration on a large `sent_emails` table before deploy.
> 
> **Overview**
> Introduces **internal bulk email** (hidden from OpenAPI): `POST /emails/bulk`, `GET /emails/bulk/:id`, and `POST /emails/bulk/:id/cancel`, wired into the e2 router.
> 
> Batches accept up to **100 one-recipient emails** (no cc/bcc), optional batch `scheduled_at`, and **Idempotency-Key** replay. Creation persists `email_batches` plus per-item `sent_emails` rows, enforces the same sender/blocklist/hourly/Autumn checks as single send, caps stored attachment bytes, and publishes **ID-only** QStash messages (content stays in DB). Publication uses an outbox model with `partially_queued` when QStash publish is incomplete; replays and status reads can **reconcile** missing or abandoned publications without double-sending.
> 
> **Cancel** flips only still-`queued` items, updates batch counters, and best-effort deletes pending QStash messages. **GET status** derives honest batch state from item rows, optionally recovers abandoned queue messages (not never-published items), and surfaces `stale_processing` for ops only.
> 
> Migration **`0072_add_internal_bulk_email.sql`** adds `email_batches` and a concurrent partial unique index on `sent_emails(batch_id, batch_index)`.
> 
> The **send-email webhook** replaces the old payload-based batch handler with `handleBulkEmailItem`: atomic **queued→processing** claims (blocked when batch is cancelled), re-checks guards/billing/blocklist at execution, **hourly-limit reschedule** via delayed QStash republish, SES throttling retries only, and strict rules post-SES to avoid duplicate sends if persistence fails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ad2407fbc8194736e080cbfd03605fea0cfed76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->